### PR TITLE
Passing region to server connection

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -60,6 +60,7 @@ module VagrantPlugins
               :availability_zone  => availability_zone,
               :flavor_id          => instance_type,
               :image_id           => ami,
+              :region             => region,
               :key_name           => keypair,
               :private_ip_address => private_ip_address,
               :subnet_id          => subnet_id,


### PR DESCRIPTION
Looks like one of the options to pass to the aws connection was missed.
This should properly set the region on the connection to the one
being passed in via the Vagrantfile.
