### PR TITLE
Adding configurable SSH port

### DIFF
--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
           # Read the DNS info
           return {
             :host => server.dns_name,
-            :port => 22,
+            :port => config.ssh_port,
             :private_key_path => config.ssh_private_key_path,
             :username => config.ssh_username
           }

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -28,6 +28,7 @@ module VagrantPlugins
           ami                = region_config.ami
           availability_zone  = region_config.availability_zone
           instance_type      = region_config.instance_type
+          ssh_port           = region_config.ssh_port
           keypair            = region_config.keypair_name
           private_ip_address = region_config.private_ip_address
           security_groups    = region_config.security_groups
@@ -50,6 +51,7 @@ module VagrantPlugins
           env[:ui].info(" -- AMI: #{ami}")
           env[:ui].info(" -- Region: #{region}")
           env[:ui].info(" -- Availability Zone: #{availability_zone}") if availability_zone
+          env[:ui].info(" -- SSH Port: #{ssh_port}") if ssh_port
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(" -- Subnet ID: #{subnet_id}") if subnet_id
           env[:ui].info(" -- Private IP: #{private_ip_address}") if private_ip_address
@@ -61,6 +63,7 @@ module VagrantPlugins
               :flavor_id          => instance_type,
               :image_id           => ami,
               :key_name           => keypair,
+              :ssh_port           => ssh_port,
               :private_ip_address => private_ip_address,
               :subnet_id          => subnet_id,
               :tags               => tags

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -50,6 +50,11 @@ module VagrantPlugins
       # @return [Array<String>]
       attr_accessor :security_groups
 
+      # The SSH port used by the instance
+      #
+      # @return [int]
+      attr_accessor :ssh_port
+
       # The path to the SSH private key to use with this EC2 instance.
       # This overrides the `config.ssh.private_key_path` variable.
       #
@@ -82,6 +87,7 @@ module VagrantPlugins
         @region             = UNSET_VALUE
         @secret_access_key  = UNSET_VALUE
         @security_groups    = UNSET_VALUE
+        @ssh_port           = UNSET_VALUE
         @ssh_private_key_path = UNSET_VALUE
         @ssh_username       = UNSET_VALUE
         @subnet_id          = UNSET_VALUE
@@ -182,6 +188,8 @@ module VagrantPlugins
 
         # The SSH values by default are nil, and the top-level config
         # `config.ssh` values are used.
+        # The SSH port should be 22 if left unset.
+        @ssh_port = 22 if @ssh_port == UNSET_VALUE
         @ssh_private_key_path = nil if @ssh_private_key_path == UNSET_VALUE
         @ssh_username = nil if @ssh_username == UNSET_VALUE
 


### PR DESCRIPTION
It defaults to 22 when left unset. I tried to keep the ordering with the ordering defined in
read_ssh_info.rb.
