### PR TITLE
VPC ssh connection address

### DIFF
--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
 
           # Read the DNS info
           return {
-            :host => server.private_ip_address.nil? ? server.dns_name : server.private_ip_address,
+            :host => server.dns_name || server.private_ip_address,
             :port => config.ssh_port,
             :private_key_path => config.ssh_private_key_path,
             :username => config.ssh_username


### PR DESCRIPTION
ssh_info.host cannot rely solely on dns_name.
private_ip_address seems the correct solution
