### PR TITLE
Prompt user for confirmation when terminating an instance.

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -11,9 +11,15 @@ module VagrantPlugins
       # This action is called to terminate the remote machine.
       def self.action_destroy
         Vagrant::Action::Builder.new.tap do |b|
-          b.use ConfigValidate
-          b.use ConnectAWS
-          b.use TerminateInstance
+          b.use Call, DestroyConfirm do |env, b2|
+            if env2[:result]
+              b2.use ConfigValidate
+              b2.use ConnectAWS
+              b2.use TerminateInstance
+            else
+              b2.use MessageWillNotDestro
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Currently when running "vagrant destroy" against a box that is an EC2 instance it just terminates the box without prompting the user. 

This addition seems like it should work but I have no way of testing it. I'd LOVE to have an automated spec against it but I am unsure of how to do so. :(
