### PR TITLE
Allow user_data in configuration

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
           security_groups    = region_config.security_groups
           subnet_id          = region_config.subnet_id
           tags               = region_config.tags
+          user_data          = region_config.user_data
 
           # If there is no keypair then warn the user
           if !keypair
@@ -66,7 +67,8 @@ module VagrantPlugins
               :ssh_port           => ssh_port,
               :private_ip_address => private_ip_address,
               :subnet_id          => subnet_id,
-              :tags               => tags
+              :tags               => tags,
+              :user_data          => user_data
             }
 
             if !security_groups.empty?

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -87,6 +87,11 @@ module VagrantPlugins
       # @return [Hash<String, String>]
       attr_accessor :tags
 
+      # The user data string
+      #
+      # @return [String]
+      attr_accessor :user_data
+
       def initialize(region_specific=false)
         @access_key_id      = UNSET_VALUE
         @ami                = UNSET_VALUE
@@ -104,6 +109,7 @@ module VagrantPlugins
         @ssh_username       = UNSET_VALUE
         @subnet_id          = UNSET_VALUE
         @tags               = {}
+        @user_data          = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -209,6 +215,9 @@ module VagrantPlugins
 
         # Subnet is nil by default otherwise we'd launch into VPC.
         @subnet_id = nil if @subnet_id == UNSET_VALUE
+
+        # User Data is nil by default
+        @user_data = nil if @user_data == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -23,6 +23,7 @@ describe VagrantPlugins::AWS::Config do
     its("ssh_username")      { should be_nil }
     its("subnet_id")         { should be_nil }
     its("tags")              { should == {} }
+    its("user_data")         { should be_nil }
   end
 
   describe "overriding defaults" do


### PR DESCRIPTION
In some cases, it's useful to pass user_data to an AMI to tweak it prior to vagrant's configuration.  In my particular case, the problem was that /etc/sudoers in the AMI included "Default requiretty", which caused vagrant sudo commands to fail.  This patch, together with an extra config line:

aws.user_data = "#!/bin/sh\nsed -i -e 's/^\(Defaults.*requiretty\)/#\1/' /etc/sudoers\n"

worked around the problem nicely.
