### PR TITLE
fallback ssh host to server.private_ip_address

### DIFF
--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
 
           # Read the DNS info
           return {
-            :host => server.dns_name,
+            :host => server.dns_name || server.private_ip_address,
             :port => config.ssh_port,
             :private_key_path => config.ssh_private_key_path,
             :username => config.ssh_username


### PR DESCRIPTION
issue #14

`server.dns_name` is empty for the common case of VPC + VPN
`server.private_ip_address` provides the correct address
