### PR TITLE
Allow getting credentials from environment variables

### DIFF
--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -174,9 +174,10 @@ module VagrantPlugins
       end
 
       def finalize!
-        # The access keys default to nil
-        @access_key_id     = nil if @access_key_id     == UNSET_VALUE
-        @secret_access_key = nil if @secret_access_key == UNSET_VALUE
+        # Try to get access keys from standard AWS environment variables; they
+        # will default to nil if the environment variables are not present.
+        @access_key_id     = ENV['AWS_ACCESS_KEY'] if @access_key_id     == UNSET_VALUE
+        @secret_access_key = ENV['AWS_SECRET_KEY'] if @secret_access_key == UNSET_VALUE
 
         # AMI must be nil, since we can't default that
         @ami = nil if @ami == UNSET_VALUE


### PR DESCRIPTION
Amazon's EC2 tools use the environment variables AWS_ACCESS_KEY and
AWS_SECRET_KEY to store credentials. This commit allows vagrant-aws to
get credentials in the same way, reducing the risk of leaking them by
removing the need to store them in the Vagrantfile.

NB This is the first time I ever write any Ruby, so some style or organisation changes might be needed on the tests.
