### PR TITLE
Add support for iam instance profiles.

### DIFF
--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -23,10 +23,14 @@ module VagrantPlugins
           # Build the fog config
           fog_config = {
             :provider              => :aws,
-            :aws_access_key_id     => region_config.access_key_id,
-            :aws_secret_access_key => region_config.secret_access_key,
             :region                => region
           }
+          if region_config.use_iam_profile
+            fog_config[:use_iam_profile] = True
+          else
+            fog_config[:aws_access_key_id] = region_config.access_key_id
+            fog_config[:aws_secret_access_key] = region_config.secret_access_key
+          end
 
           fog_config[:endpoint] = region_config.endpoint if region_config.endpoint
           fog_config[:version]  = region_config.version if region_config.version

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -29,6 +29,7 @@ describe VagrantPlugins::AWS::Config do
     its("subnet_id")         { should be_nil }
     its("tags")              { should == {} }
     its("user_data")         { should be_nil }
+    its("use_iam_profile")   { should be_false }
   end
 
   describe "overriding defaults" do
@@ -46,6 +47,11 @@ describe VagrantPlugins::AWS::Config do
         instance.finalize!
         instance.send(attribute).should == "foo"
       end
+    end
+    it "should be true if overriden" do
+      instance.use_iam_profile = true
+      instance.finalize!
+      instance.use_iam_profile.should be_true
     end
   end
 
@@ -75,6 +81,23 @@ describe VagrantPlugins::AWS::Config do
 
       its("access_key_id")     { should == "access_key" }
       its("secret_access_key") { should == "secret_key" }
+    end
+  end
+
+  describe "Working with instance profiles" do
+    context "Using iam instance profile" do
+      subject do
+        instance.tap do |o|
+          o.use_iam_profile = true
+          o.access_key_id = nil
+          o.secret_access_key = nil
+          o.finalize!
+        end
+      end
+
+      its("access_key_id")     { should be_nil }
+      its("secret_access_key") { should be_nil }
+      its("use_iam_profile")   { should be_true }
     end
   end
 

--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-aws"
 
-  s.add_runtime_dependency "fog", "~> 1.10.0"
+  s.add_runtime_dependency "fog", "~> 1.10.1"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"


### PR DESCRIPTION
With iam instance profiles, you no longer need to explicitly provide 
credentials. Temporary ones are generated on the server. Setting the 
use_iam_profile variable in config will have it use those credentials instead
