### PR TITLE
fog's wait_for throwing exception on run_instance.rb

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -101,7 +101,7 @@ module VagrantPlugins
               next if env[:interrupted]
 
               # Wait for the server to be ready
-              server.wait_for(2) { ready? }
+              server.wait_for(10) { ready? }
             end
           end
 


### PR DESCRIPTION
2 seconds isn't long enough. For giggles, I changed to 10 and was able to boot up an instance.

I think fog's _fog/core/wait_for.rb:wait_for_ changed from returning false on a timeout to throwing an exception.

(I'm new to vagrant and not a native ruby speaker)
