### PR TITLE
Vagrant reload feature

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -109,6 +109,18 @@ module VagrantPlugins
         end
       end
 
+      # This action is called to resync shared folders
+      def self.action_reload
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectAWS
+          b.use Call, IsCreated do |env, b2|
+            b2.use SyncFolders
+          end
+        end
+      end
+
+
       # The autoload farm
       action_root = Pathname.new(File.expand_path("../action", __FILE__))
       autoload :ConnectAWS, action_root.join("connect_aws")


### PR DESCRIPTION
I've written simple patch that adds vagrant reload feature. It isn't full reload, because vagrant halt is not yet implemented.
My patch adds support for synchronizing shared folders.
