### PR TITLE
Handle config.vm.box_url

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -93,6 +93,7 @@ module VagrantPlugins
       # This action is called to bring the box up from nothing.
       def self.action_up
         Vagrant::Action::Builder.new.tap do |b|
+          b.use HandleBoxUrl
           b.use ConfigValidate
           b.use ConnectAWS
           b.use Call, IsCreated do |env, b2|


### PR DESCRIPTION
Adds support for config.vm.box_url by using the HandleBoxUrl middleware. A separate commit also fixes a small typo (env vs env2) in `lib/vagrant-aws/action.rb` that breaks `vagrant destroy`.
