### PR TITLE
support for folder sync via rsync on windows.

### DIFF
--- a/lib/vagrant-aws/action/sync_folders.rb
+++ b/lib/vagrant-aws/action/sync_folders.rb
@@ -4,6 +4,8 @@ require "vagrant/util/subprocess"
 
 require "vagrant/util/scoped_hash_override"
 
+require "vagrant/util/which"
+
 module VagrantPlugins
   module AWS
     module Action
@@ -27,6 +29,11 @@ module VagrantPlugins
 
             # Ignore disabled shared folders
             next if data[:disabled]
+
+            unless Vagrant::Util::Which.which('rsync')
+              env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning'))
+              break
+            end
 
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,9 @@ en:
       Instance is not created. Please run `vagrant up` first.
     ready: |-
       Machine is booted and ready for use!
+    rsync_not_found_warning: |-
+      Warning! Folder sync disabled because the rsync binary is missing.
+      Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
     terminating: |-


### PR DESCRIPTION
rsync interprets paths with colons as remote locations.
This leads to _"The source and destination cannot both be remote."_ erros when using local paths like `c:\vagrant` for the hostpath.
This commits converts the hostpath to /cygdrive/... notation on windows in general.
I confirmed that this works with the cwRsync Installer (https://www.itefix.no/i2/cwrsync).
