### PR TITLE
Added ability to launch EC2 instances with an IAM Instance Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ This provider exposes quite a few provider-specific configuration options:
 * `security_groups` - An array of security groups for the instance. If this
   instance will be launched in VPC, this must be a list of security group
   IDs.
+* `iam_instance_profile_arn` - The Amazon resource name (ARN) of the IAM Instance
+    Profile to associate with the instance
+* `iam_instance_profile_name` - The name of the IAM Instance Profile to associate
+  with the instance
 * `subnet_id` - The subnet to boot the instance into, for VPC.
 * `tags` - A hash of tags to set on the machine.
 * `use_iam_profile` - If true, will use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -32,6 +32,8 @@ module VagrantPlugins
           private_ip_address = region_config.private_ip_address
           security_groups    = region_config.security_groups
           subnet_id          = region_config.subnet_id
+          iam_instance_profile_arn  = region_config.iam_instance_profile_arn
+          iam_instance_profile_name = region_config.iam_instance_profile_name
           tags               = region_config.tags
           user_data          = region_config.user_data
 
@@ -53,6 +55,8 @@ module VagrantPlugins
           env[:ui].info(" -- Availability Zone: #{availability_zone}") if availability_zone
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(" -- Subnet ID: #{subnet_id}") if subnet_id
+          env[:ui].info(" -- IAM Instance Profile ARN: #{iam_instance_profile_arn}") if iam_instance_profile_arn
+          env[:ui].info(" -- IAM Instance Profile Name: #{iam_instance_profile_name}") if iam_instance_profile_name
           env[:ui].info(" -- Private IP: #{private_ip_address}") if private_ip_address
           env[:ui].info(" -- User Data: yes") if user_data
           env[:ui].info(" -- Security Groups: #{security_groups.inspect}") if !security_groups.empty?
@@ -66,6 +70,8 @@ module VagrantPlugins
               :key_name           => keypair,
               :private_ip_address => private_ip_address,
               :subnet_id          => subnet_id,
+              :iam_instance_profile_arn   => iam_instance_profile_arn,
+              :iam_instance_profile_name  => iam_instance_profile_name,
               :tags               => tags,
               :user_data          => user_data
             }

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -65,6 +65,18 @@ module VagrantPlugins
       # @return [Array<String>]
       attr_accessor :security_groups
 
+      # The Amazon resource name (ARN) of the IAM Instance Profile
+      # to associate with the instance.
+      #
+      # @return [String]
+      attr_accessor :iam_instance_profile_arn
+
+      # The name of the IAM Instance Profile to associate with
+      # the instance.
+      #
+      # @return [String]
+      attr_accessor :iam_instance_profile_name
+
       # The subnet ID to launch the machine into (VPC).
       #
       # @return [String]
@@ -99,6 +111,8 @@ module VagrantPlugins
         @version            = UNSET_VALUE
         @secret_access_key  = UNSET_VALUE
         @security_groups    = UNSET_VALUE
+        @iam_instance_profile_arn   = UNSET_VALUE
+        @iam_instance_profile_name  = UNSET_VALUE
         @subnet_id          = UNSET_VALUE
         @tags               = {}
         @user_data          = UNSET_VALUE
@@ -205,6 +219,10 @@ module VagrantPlugins
 
         # Subnet is nil by default otherwise we'd launch into VPC.
         @subnet_id = nil if @subnet_id == UNSET_VALUE
+
+        # IAM Instance profile arn/name is nil by default.
+        @iam_instance_profile_arn   = nil if @iam_instance_profile_arn  == UNSET_VALUE
+        @iam_instance_profile_name  = nil if @iam_instance_profile_name == UNSET_VALUE
 
         # By default we don't use an IAM profile
         @use_iam_profile = false if @use_iam_profile == UNSET_VALUE

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -26,6 +26,8 @@ describe VagrantPlugins::AWS::Config do
     its("secret_access_key") { should be_nil }
     its("security_groups")   { should == [] }
     its("subnet_id")         { should be_nil }
+    its("iam_instance_profile_arn") { should be_nil }
+    its("iam_instance_profile_name") { should be_nil }
     its("tags")              { should == {} }
     its("user_data")         { should be_nil }
     its("use_iam_profile")   { should be_false }
@@ -39,7 +41,8 @@ describe VagrantPlugins::AWS::Config do
     [:access_key_id, :ami, :availability_zone, :instance_ready_timeout,
       :instance_type, :keypair_name,
       :region, :secret_access_key, :security_groups,
-      :subnet_id, :tags,
+      :subnet_id, :iam_instance_profile_arn,
+      :iam_instance_profile_name, :tags,
       :use_iam_profile, :user_data].each do |attribute|
 
       it "should not default #{attribute} if overridden" do


### PR DESCRIPTION
Support was already there to launch instances using IAM role credentials (https://github.com/mitchellh/vagrant-aws/pull/41), but I needed a way to launch an EC2 instance that had an IAM instance profile itself.

The AWS API (and Fog) let you refer to an IAM Instance Profile with either an ARN or a name.  I added support for both.
