### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,24 @@ the AWS machine.
 ## Synced Folders
 
 There is minimal support for synced folders. Upon `vagrant up`,
-`vagrant reload`, and `vagrant provision`, the AWS provider will use
+ and `vagrant provision`, the AWS provider will use
 `rsync` (if available) to uni-directionally sync the folder to
 the remote machine over SSH.
 
 This is good enough for all built-in Vagrant provisioners (shell,
 chef, and puppet) to work!
+
+## Amazon Linux AMI's
+
+[Amazon Linux AMIs](http://aws.amazon.com/amazon-linux-ami/) are set 
+to require tty when sudo'ing, which causes problems when Vagrant tries
+to do things like setup the rsync folder. In order to get around this
+you can send aws user_data to populate the cloud init config and change this
+for the ec2-user when the instance is created:
+
+```ruby
+aws.user_data = "#!/bin/bash\necho 'Defaults:ec2-user !requiretty' > /etc/sudoers.d/999-vagrant-cloud-init-requiretty && chmod 440 /etc/sudoers.d/999-vagrant-cloud-init-requiretty\nyum install -y puppet\n"
+```
 
 ## Other Examples
 


### PR DESCRIPTION
I removed the 'reload' reference in the sync section because it is not implemented for the aws provider.

I also added notes on how to get around the tty issue for Amazon Linux AMIs.  I realize this is image specific, but as this provider does not work out of the box with the stock/default AMIs that are most common to AWS this seems like it would be helpful information for those getting started.
