### PR TITLE
Add translation for pending messages

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -74,3 +74,9 @@ en:
       long_running: |-
         The EC2 instance is running. To stop this machine, you can run
         `vagrant halt`. To destroy the machine, you can run `vagrant destroy`.
+
+      short_pending: |-
+        pending
+      long_pending: |-
+        The EC2 instance is still being initialized. To destroy this machine,
+        you can run `vagrant destroy`.


### PR DESCRIPTION
This state would be reached if you are starting a box and it hasn't finished being set up, and from another command window you query `vagrant status`. For example, previously I got:

```
Current machine states:

default          translation missing: en.vagrant_aws.states.short_pending (aws)

translation missing: en.vagrant_aws.states.long_pending
```

And after this patch I get:

```
Current machine states:

default                  pending (aws)

The EC2 instance is still being initialized. To destroy this machine,
you can run `vagrant destroy`.
```

Hope this helps.
