### PR TITLE
Fix rsync on windows (alternative)

### DIFF
--- a/lib/vagrant-aws/action/sync_folders.rb
+++ b/lib/vagrant-aws/action/sync_folders.rb
@@ -4,6 +4,8 @@ require "vagrant/util/subprocess"
 
 require "vagrant/util/scoped_hash_override"
 
+require "vagrant/util/which"
+
 module VagrantPlugins
   module AWS
     module Action
@@ -27,6 +29,11 @@ module VagrantPlugins
 
             # Ignore disabled shared folders
             next if data[:disabled]
+
+            unless Vagrant::Util::Which.which('rsync')
+              env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning'))
+              break
+            end
 
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,9 @@ en:
       Instance is not created. Please run `vagrant up` first.
     ready: |-
       Machine is booted and ready for use!
+    rsync_not_found_warning: |-
+      Warning! Folder sync disabled because the rsync binary is missing.
+      Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
     terminating: |-


### PR DESCRIPTION
Alternative to PR #67, akin to how it is [solved in mccloud](https://github.com/tknerr/mccloud/commit/56fc78eb0640bc8ac51b85a472ec3bab17ac0989) and [knife-solo](https://github.com/tknerr/knife-solo/commit/21def85d7d8c633ff2f47dd27afbbe88d5085252):
- convert to `/cygdrive/..` style pathnames on windows
- fix permissions by setting `--chmod ugo=rwX` on windows
- warn if no `rsync` available (cherry-picked 114e10e1ec613deffcc85851015e2db748332714 from @databus23) 

See [this comment](https://github.com/mitchellh/vagrant-aws/pull/67#issuecomment-18865716) for more details.
