### PR TITLE
Pass public and private IP addresses to ssh_info hash

### DIFF
--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -32,6 +32,8 @@ module VagrantPlugins
           # Read the DNS info
           return {
             :host => server.dns_name || server.private_ip_address,
+            :private_ip => server.private_ip_address,
+            :public_ip => server.public_ip_address,
             :port => 22
           }
         end


### PR DESCRIPTION
This will be handy in conjunction with vagrant-hostmaster plugin. Vagrant Hostmaster could benefit from these data,
to setup private IP addresses in /etc/hosts on each machine.
