### PR TITLE
Simple elb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+### Elastic Load Balancers
+
+You can automatically attach an instance to an ELB during boot and detach on destroy.
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ... other stuff
+
+  config.vm.provider "aws" do |aws|
+    aws.elb = "production-web"
+  end
+end
+
+```
+
 ## Development
 
 To work on the `vagrant-aws` plugin, clone this repository out, and use

--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
             if env[:result]
               b2.use ConfigValidate
               b2.use ConnectAWS
+              b2.use ElbDeregisterInstance
               b2.use TerminateInstance
             else
               b2.use MessageWillNotDestroy
@@ -105,6 +106,7 @@ module VagrantPlugins
             b2.use TimedProvision
             b2.use SyncFolders
             b2.use WarnNetworks
+            b2.use ElbRegisterInstance
             b2.use RunInstance
           end
         end
@@ -124,6 +126,8 @@ module VagrantPlugins
       autoload :TimedProvision, action_root.join("timed_provision")
       autoload :WarnNetworks, action_root.join("warn_networks")
       autoload :TerminateInstance, action_root.join("terminate_instance")
+      autoload :ElbRegisterInstance, action_root.join("elb_register_instance")
+      autoload :ElbDeregisterInstance, action_root.join("elb_deregister_instance")
     end
   end
 end

--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -37,6 +37,7 @@ module VagrantPlugins
 
           @logger.info("Connecting to AWS...")
           env[:aws_compute] = Fog::Compute.new(fog_config)
+          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.except(:provider))
 
           @app.call(env)
         end

--- a/lib/vagrant-aws/action/elb_deregister_instance.rb
+++ b/lib/vagrant-aws/action/elb_deregister_instance.rb
@@ -1,0 +1,24 @@
+require 'vagrant-aws/util/elb'
+
+module VagrantPlugins
+  module AWS
+    module Action
+      # This registers instance in ELB
+      class ElbDeregisterInstance
+        include ElasticLoadBalancer
+
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_aws::action::elb_deregister_instance")
+        end
+
+        def call(env)
+          if elb_name = env[:machine].provider_config.elb
+            deregister_instance env, elb_name, env[:machine].id
+          end
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-aws/action/elb_register_instance.rb
+++ b/lib/vagrant-aws/action/elb_register_instance.rb
@@ -1,0 +1,24 @@
+require 'vagrant-aws/util/elb'
+
+module VagrantPlugins
+  module AWS
+    module Action
+      # This registers instance in ELB
+      class ElbRegisterInstance
+        include ElasticLoadBalancer
+
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_aws::action::elb_register_instance")
+        end
+
+        def call(env)
+          @app.call(env)
+          if elb_name = env[:machine].provider_config.elb
+            register_instance env, elb_name, env[:machine].id
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -32,8 +32,6 @@ module VagrantPlugins
           # Read the DNS info
           return {
             :host => server.dns_name || server.private_ip_address,
-            :private_ip => server.private_ip_address,
-            :public_ip => server.public_ip_address,
             :port => 22
           }
         end

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -86,6 +86,12 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :user_data
 
+      # The name of ELB, which an instance should be
+      # attached to
+      #
+      # @return [String]
+      attr_accessor :elb
+
       def initialize(region_specific=false)
         @access_key_id      = UNSET_VALUE
         @ami                = UNSET_VALUE
@@ -102,6 +108,7 @@ module VagrantPlugins
         @subnet_id          = UNSET_VALUE
         @tags               = {}
         @user_data          = UNSET_VALUE
+        @elb                = UNSET_VALUE
         @use_iam_profile    = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
@@ -211,6 +218,9 @@ module VagrantPlugins
 
         # User Data is nil by default
         @user_data = nil if @user_data == UNSET_VALUE
+
+        # Don't attach instance to any ELB by default
+        @elb = nil if @elb == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.

--- a/lib/vagrant-aws/errors.rb
+++ b/lib/vagrant-aws/errors.rb
@@ -18,6 +18,10 @@ module VagrantPlugins
       class RsyncError < VagrantAWSError
         error_key(:rsync_error)
       end
+
+      class ElbDoesNotExistError < VagrantAWSError
+        error_key("elb_does_not_exist")
+      end
     end
   end
 end

--- a/lib/vagrant-aws/util/elb.rb
+++ b/lib/vagrant-aws/util/elb.rb
@@ -1,0 +1,56 @@
+module VagrantPlugins
+  module AWS
+    module ElasticLoadBalancer
+
+      def register_instance(env, elb_name, instance_id)
+        env[:ui].info I18n.t("vagrant_aws.elb.registering", instance_id: instance_id, elb_name: elb_name), :new_line => false
+        elb = get_load_balancer(env[:aws_elb], elb_name)
+        unless elb.instances.include? instance_id
+          elb.register_instances([instance_id])
+          env[:ui].info I18n.t("vagrant_aws.elb.ok"), :prefix => false
+          adjust_availability_zones env, elb
+        else
+          env[:ui].info I18n.t("vagrant_aws.elb.skipped"), :prefix => false
+        end
+      end
+
+      def deregister_instance(env, elb_name, instance_id)
+        env[:ui].info I18n.t("vagrant_aws.elb.deregistering", instance_id: instance_id, elb_name: elb_name), :new_line => false
+        elb = get_load_balancer(env[:aws_elb], elb_name)
+        if elb.instances.include? instance_id
+          elb.deregister_instances([instance_id])
+          env[:ui].info I18n.t("vagrant_aws.elb.ok"), :prefix => false
+          adjust_availability_zones env, elb
+        else
+          env[:ui].info I18n.t("vagrant_aws.elb.skipped"), :prefix => false
+        end
+      end
+
+      def adjust_availability_zones(env, elb)
+        env[:ui].info I18n.t("vagrant_aws.elb.adjusting", elb_name: elb.id), :new_line => false
+
+        instances = env[:aws_compute].servers.all("instance-id" => elb.instances)
+        
+        azs = if instances.empty?
+                ["#{env[:machine].provider_config.region}a"]
+              else
+                instances.map(&:availability_zone).uniq
+              end
+
+        az_to_disable = elb.availability_zones - azs
+        az_to_enable = azs - elb.availability_zones
+
+        elb.enable_availability_zones az_to_enable unless az_to_enable.empty?
+        elb.disable_availability_zones az_to_disable unless az_to_disable.empty?
+
+        env[:ui].info I18n.t("vagrant_aws.elb.ok"), :prefix => false
+      end
+
+      private
+
+      def get_load_balancer(aws, name)
+        aws.load_balancers.find { |lb| lb.id == name } or raise Errors::ElbDoesNotExistError
+      end
+    end
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,13 @@ en:
   vagrant_aws:
     already_created: |-
       The machine is already created.
+    elb:
+      adjusting: "Adjusting availability zones of ELB %{elb_name}... "
+      registering: "Registering %{instance_id} at ELB %{elb_name}... "
+      deregistering: "Deregistering %{instance_id} from ELB %{elb_name}... " 
+      ok: "ok"
+      skipped: "skipped"
+
     launching_instance: |-
       Launching an instance with the following settings...
     launch_no_keypair: |-
@@ -62,6 +69,8 @@ en:
         Host path: %{hostpath}
         Guest path: %{guestpath}
         Error: %{stderr}
+      elb_does_not_exist: |-
+        ELB configured for the instance does not exist
 
     states:
       short_not_created: |-


### PR DESCRIPTION
Adds functionality of adding and removing instances from AWS ELB.
ELB must exist in the first place.

This partially fixes mitchellh/vagrant-aws#53
