### PR TITLE
Add block_device_mapping support (cleaned up and re-req'd)

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -24,16 +24,17 @@ module VagrantPlugins
           region = env[:machine].provider_config.region
 
           # Get the configs
-          region_config      = env[:machine].provider_config.get_region_config(region)
-          ami                = region_config.ami
-          availability_zone  = region_config.availability_zone
-          instance_type      = region_config.instance_type
-          keypair            = region_config.keypair_name
-          private_ip_address = region_config.private_ip_address
-          security_groups    = region_config.security_groups
-          subnet_id          = region_config.subnet_id
-          tags               = region_config.tags
-          user_data          = region_config.user_data
+          region_config         = env[:machine].provider_config.get_region_config(region)
+          ami                   = region_config.ami
+          availability_zone     = region_config.availability_zone
+          instance_type         = region_config.instance_type
+          keypair               = region_config.keypair_name
+          private_ip_address    = region_config.private_ip_address
+          security_groups       = region_config.security_groups
+          subnet_id             = region_config.subnet_id
+          tags                  = region_config.tags
+          user_data             = region_config.user_data
+          block_device_mapping  = region_config.block_device_mapping
 
           # If there is no keypair then warn the user
           if !keypair
@@ -57,6 +58,7 @@ module VagrantPlugins
           env[:ui].info(" -- User Data: yes") if user_data
           env[:ui].info(" -- Security Groups: #{security_groups.inspect}") if !security_groups.empty?
           env[:ui].info(" -- User Data: #{user_data}") if user_data
+          env[:ui].info(" -- Block Device Mapping: #{block_device_mapping}") if block_device_mapping
 
           begin
             options = {
@@ -67,7 +69,8 @@ module VagrantPlugins
               :private_ip_address => private_ip_address,
               :subnet_id          => subnet_id,
               :tags               => tags,
-              :user_data          => user_data
+              :user_data          => user_data,
+              :block_device_mapping => block_device_mapping
             }
 
             if !security_groups.empty?

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -86,23 +86,26 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :user_data
 
+      attr_accessor :block_device_mapping
+
       def initialize(region_specific=false)
-        @access_key_id      = UNSET_VALUE
-        @ami                = UNSET_VALUE
-        @availability_zone  = UNSET_VALUE
+        @access_key_id          = UNSET_VALUE
+        @ami                    = UNSET_VALUE
+        @availability_zone      = UNSET_VALUE
         @instance_ready_timeout = UNSET_VALUE
-        @instance_type      = UNSET_VALUE
-        @keypair_name       = UNSET_VALUE
-        @private_ip_address = UNSET_VALUE
-        @region             = UNSET_VALUE
-        @endpoint           = UNSET_VALUE
-        @version            = UNSET_VALUE
-        @secret_access_key  = UNSET_VALUE
-        @security_groups    = UNSET_VALUE
-        @subnet_id          = UNSET_VALUE
-        @tags               = {}
-        @user_data          = UNSET_VALUE
-        @use_iam_profile    = UNSET_VALUE
+        @instance_type          = UNSET_VALUE
+        @keypair_name           = UNSET_VALUE
+        @private_ip_address     = UNSET_VALUE
+        @region                 = UNSET_VALUE
+        @endpoint               = UNSET_VALUE
+        @version                = UNSET_VALUE
+        @secret_access_key      = UNSET_VALUE
+        @security_groups        = UNSET_VALUE
+        @subnet_id              = UNSET_VALUE
+        @tags                   = {}
+        @user_data              = UNSET_VALUE
+        @use_iam_profile        = UNSET_VALUE
+        @block_device_mapping   = {}
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -29,6 +29,7 @@ describe VagrantPlugins::AWS::Config do
     its("tags")              { should == {} }
     its("user_data")         { should be_nil }
     its("use_iam_profile")   { should be_false }
+    its("block_device_mapping")  {should == {} }
   end
 
   describe "overriding defaults" do
@@ -40,7 +41,7 @@ describe VagrantPlugins::AWS::Config do
       :instance_type, :keypair_name,
       :region, :secret_access_key, :security_groups,
       :subnet_id, :tags,
-      :use_iam_profile, :user_data].each do |attribute|
+      :use_iam_profile, :user_data, :block_device_mapping].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
         instance.send("#{attribute}=".to_sym, "foo")


### PR DESCRIPTION
Support the block_device_mapping attribute when creating a new ec2 instance.

Example:

``` ruby
aws.block_device_mapping = [
    {
        :DeviceName => "/dev/sdb", 
        :VirtualName => "ephemeral0"
    },
    {
        :DeviceName => "/dev/sdc", 
        :VirtualName => "ephemeral1"
    }
]
```
