### PR TITLE
Detailed error on HTTPStatusError (issue #75)

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -87,6 +87,8 @@ module VagrantPlugins
             raise
           rescue Fog::Compute::AWS::Error => e
             raise Errors::FogError, :message => e.message
+          rescue Excon::Errors::HTTPStatusError => e
+            raise Excon::Errors::HTTPStatusError, :message => e.response
           end
 
           # Immediately save the ID since it is created at this point.


### PR DESCRIPTION
Like others, I've had the problem with the lack of detailed error. I first tried updating fog locally but the error was still "Expected(200) <=> Actual(400 Bad Request)".

Since the excon gem (dependency of the fog gem) is the one throwing the error, I thought we'd catch that and display the actual response. If there's a nicer way of doing it let me know (i.e., just showing the `response.body`? that would be amazon's response XML). I don't know any ruby so I just kinda did as much as I could. No tests either, but would love to learn.

Anyway, this revealed to me, for example, that the AMI image id I was using was apparently invalid. I grabbed it from some other tutorial as I'm learning vagrant - so who'da thunk it would be wrong?
