### PR TITLE
add ssh override option

### DIFF
--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -30,11 +30,15 @@ module VagrantPlugins
           end
 
           # Read the DNS info
+          ssh_host_attribute_override = machine.provider_config.
+              get_region_config(machine.provider_config.region).ssh_host_attribute
           return {
-            :host => server.public_ip_address || server.dns_name || server.private_ip_address,
+            :host => ssh_host_attribute_override ? server.public_send(ssh_host_attribute_override) :
+                server.public_ip_address || server.dns_name || server.private_ip_address,
             :port => 22
           }
         end
+
       end
     end
   end

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -113,6 +113,15 @@ module VagrantPlugins
       # @return [bool]
       attr_accessor :terminate_on_shutdown
 
+      # Specifies which address to connect to with ssh
+      # Must be one of:
+      #  - :public_ip_address
+      #  - :dns_name
+      #  - :private_ip_address
+      #
+      # @return [Symbol]
+      attr_accessor :ssh_host_attribute
+
       def initialize(region_specific=false)
         @access_key_id          = UNSET_VALUE
         @ami                    = UNSET_VALUE
@@ -135,6 +144,7 @@ module VagrantPlugins
         @iam_instance_profile_arn  = UNSET_VALUE
         @iam_instance_profile_name = UNSET_VALUE
         @terminate_on_shutdown  = UNSET_VALUE
+        @ssh_host_attribute    = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -257,6 +267,9 @@ module VagrantPlugins
 
         # default false
         @terminate_on_shutdown = false if @terminate_on_shutdown == UNSET_VALUE
+
+        # default to nil
+        @ssh_host_attribute = nil if @ssh_host_attribute == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.


### PR DESCRIPTION
This allows the user to connect via ssh to a different address than the public one, if it's unavailable.
