### PR TITLE
support user specified rsync excludes.

### DIFF
--- a/lib/vagrant-aws/action/sync_folders.rb
+++ b/lib/vagrant-aws/action/sync_folders.rb
@@ -66,11 +66,14 @@ module VagrantPlugins
             env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
             env[:machine].communicate.sudo(
               "chown #{ssh_info[:username]} '#{guestpath}'")
+ 
+            #collect rsync excludes specified :rsync_excludes=>['path1',...] in synced_folder options
+            excludes = ['.vagrant/', 'Vagrantfile', *Array(data[:rsync_excludes])]
 
             # Rsync over to the guest path using the SSH info
             command = [
               "rsync", "--verbose", "--archive", "-z",
-              "--exclude", ".vagrant/", "--exclude", "Vagrantfile",
+              *excludes.map{|e|['--exclude', e]}.flatten,
               "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]


### PR DESCRIPTION
This pull request is a simple solution for configurable rsync excludes requested in #140 and #152.

Instead of introducing a new plugin specific configuration option this change uses the already existing options hash of synced folders.
It allows to specify excludes for each defined synced folder in the Vagrantfile.
e.g.:

```
config.vm.synced_folder '.', '/vagrant', :rsync_excludes => ['chef/tmp', 'tmp']
```
