### PR TITLE
Elastic IP is not released when instance is destroyed

### DIFF
--- a/lib/vagrant-aws/action/terminate_instance.rb
+++ b/lib/vagrant-aws/action/terminate_instance.rb
@@ -14,17 +14,17 @@ module VagrantPlugins
         def call(env)
           server = env[:aws_compute].servers.get(env[:machine].id)
 
-          # Destroy the server and remove the tracking ID
-          env[:ui].info(I18n.t("vagrant_aws.terminating"))
-          server.destroy
-          env[:machine].id = nil
-
           # Release the elastic IP
           ip_file = env[:machine].data_dir.join('elastic_ip')
           if ip_file.file?
             release_address(env,ip_file.read)
             ip_file.delete
           end
+
+          # Destroy the server and remove the tracking ID
+          env[:ui].info(I18n.t("vagrant_aws.terminating"))
+          server.destroy
+          env[:machine].id = nil
 
           @app.call(env)
         end


### PR DESCRIPTION
I seem to be having an issue with releasing Elastic IPs.  I am running Vagrant 1.3.5.  It seems that calling `server.destroy` removes `ip_file` before `release_address` is called, causing the Elastic IP to stick around after instance termination.

Attempting to remove the Elastic IP before calling `server.destroy` fixes this for me.
