### PR TITLE
Fix Vagrant 1.4 compatibility and support multiple SSH keys

### DIFF
--- a/lib/vagrant-aws/action/sync_folders.rb
+++ b/lib/vagrant-aws/action/sync_folders.rb
@@ -76,7 +76,7 @@ module VagrantPlugins
             command = [
               "rsync", "--verbose", "--archive", "-z",
               "--exclude", ".vagrant/", "--exclude", "Vagrantfile",
-              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
+              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options(ssh_info)}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
 
@@ -94,6 +94,13 @@ module VagrantPlugins
                 :stderr => r.stderr
             end
           end
+        end
+
+        private
+
+        def ssh_key_options(ssh_info)
+          # Ensure that `private_key_path` is an Array (for Vagrant < 1.4)
+          Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
         end
       end
     end


### PR DESCRIPTION
Vagrant 1.4.0 added support for multiple SSH keys (mitchellh/vagrant#907) and changed `private_key_path` to an Array.

This PR ensures we always handle it as array to keep compatible with both old and new Vagrant versions. Also pass all of the specified keys to rsync/ssh command.

Fixes #171
