### PR TITLE
Add ProvisionerCleanup to the destroy action middleware stack

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -38,6 +38,7 @@ module VagrantPlugins
               end
               b2.use ConnectAWS
               b2.use TerminateInstance
+              b2.use ProvisionerCleanup if defined?(ProvisionerCleanup)
             else
               b2.use MessageWillNotDestroy
             end


### PR DESCRIPTION
Call cleanup method of the provisioners.

Fixes #170
