### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `secret_access_key` - The secret access key for accessing AWS
 * `security_groups` - An array of security groups for the instance. If this
   instance will be launched in VPC, this must be a list of security group
-  IDs.
+  names.
 * `iam_instance_profile_arn` - The Amazon resource name (ARN) of the IAM Instance
     Profile to associate with the instance
 * `iam_instance_profile_name` - The name of the IAM Instance Profile to associate


### PR DESCRIPTION
Documentation specifies the IDs which does not work, it needs to use the names of the security groups.

ids:
aws.security_groups = ["sg-abc123"]
names:
aws.security_groups = ["ssh"]
