### PR TITLE
vagrant-aws gemspec is too pessimistic about fog, can cause downgrades that break vagrant

### DIFF
--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-aws"
 
-  s.add_runtime_dependency "fog", "~> 1.18.0"
+  s.add_runtime_dependency "fog", "~> 1.18"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"


### PR DESCRIPTION
vagrant-aws doesn't follow [fog's recommendation](https://github.com/fog/fog/blob/master/README.md#versioning) to only specify two digits of precision for fog, because it uses semantic versioning.

Normally this would just cause unnecessary, superficial conflicts with other plugins.  However, because vagrant's handling of gem conflicts still has some quirks, the actual result is much more severe.  Sometimes vagrant will downgrade the vagrant-aws gem to 0.0.1 (rather than downgrading fog) and you will get the error below (originally reported via https://github.com/mitchellh/vagrant-rackspace/issues/81) when you run a vagrant command:

```
ERROR vagrant: The plugins failed to load properly. The error message given is shown below.

uninitialized constant Vagrant::VM
ERROR vagrant: /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant.rb:264:in `rescue in <top  (required)>'
/opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant.rb:260:in `<top (required)>'
/opt/vagrant/bin/../embedded/gems/gems/vagrant-1.5.1/bin/vagrant:95:in `require'
/opt/vagrant/bin/../embedded/gems/gems/vagrant-1.5.1/bin/vagrant:95:in `<main>'
Vagrant failed to initialize at a very early stage:
     The plugins failed to load properly. The error message given is shown below.
   uninitialized constant Vagrant::VM
```

I was able to reproduce and modify vagrant to get a slightly more complete stacktrace, showing the error is occurring in an old version of vagrant-aws:

```
#<NameError: uninitialized constant Vagrant::VM>
/Users/Thoughtworker/.vagrant.d/gems/gems/vagrant-aws-0.0.1/lib/vagrant-aws/vm.rb:19:in `<module:VagrantAWS>'
/Users/Thoughtworker/.vagrant.d/gems/gems/vagrant-aws-0.0.1/lib/vagrant-aws/vm.rb:17:in `<top (required)>'
/Users/Thoughtworker/.vagrant.d/gems/gems/vagrant-aws-0.0.1/lib/vagrant-aws.rb:5:in `require'
/Users/Thoughtworker/.vagrant.d/gems/gems/vagrant-aws-0.0.1/lib/vagrant-aws.rb:5:in `<top (required)>'
/Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/runtime.rb:76:in `require'
```
