### PR TITLE
Add a config parameter to specify whether public IP is assigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `iam_instance_profile_name` - The name of the IAM Instance Profile to associate
   with the instance
 * `subnet_id` - The subnet to boot the instance into, for VPC.
+* `associate_public_ip` - If true, will associate a public IP address to an instance in a VPC.
 * `tags` - A hash of tags to set on the machine.
 * `use_iam_profile` - If true, will use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
   for credentials.

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -42,6 +42,7 @@ module VagrantPlugins
           iam_instance_profile_name = region_config.iam_instance_profile_name
           monitoring            = region_config.monitoring
           ebs_optimized         = region_config.ebs_optimized
+          associate_public_ip   = region_config.associate_public_ip
 
           # If there is no keypair then warn the user
           if !keypair
@@ -72,6 +73,7 @@ module VagrantPlugins
           env[:ui].info(" -- Terminate On Shutdown: #{terminate_on_shutdown}")
           env[:ui].info(" -- Monitoring: #{monitoring}")
           env[:ui].info(" -- EBS optimized: #{ebs_optimized}")
+          env[:ui].info(" -- Assigning a public IP address in a VPC: #{associate_public_ip}")
 
           options = {
             :availability_zone         => availability_zone,
@@ -87,7 +89,8 @@ module VagrantPlugins
             :block_device_mapping      => block_device_mapping,
             :instance_initiated_shutdown_behavior => terminate_on_shutdown == true ? "terminate" : nil,
             :monitoring                => monitoring,
-            :ebs_optimized             => ebs_optimized
+            :ebs_optimized             => ebs_optimized,
+            :associate_public_ip        => associate_public_ip
           }
           if !security_groups.empty?
             security_group_key = options[:subnet_id].nil? ? :groups : :security_group_ids

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -133,6 +133,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :ebs_optimized
 
+      # Assigning a public IP address in a VPC
+      #
+      # @return [Boolean]
+      attr_accessor :associate_public_ip
+
       def initialize(region_specific=false)
         @access_key_id          = UNSET_VALUE
         @ami                    = UNSET_VALUE
@@ -158,6 +163,7 @@ module VagrantPlugins
         @ssh_host_attribute     = UNSET_VALUE
         @monitoring             = UNSET_VALUE
         @ebs_optimized          = UNSET_VALUE
+        @associate_public_ip    = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -296,6 +302,9 @@ module VagrantPlugins
         # default false
         @ebs_optimized = false if @ebs_optimized == UNSET_VALUE
 
+        # default false
+        @associate_public_ip = false if @associate_public_ip == UNSET_VALUE
+
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.
         if !@__region_specific
@@ -336,6 +345,10 @@ module VagrantPlugins
               config.access_key_id.nil?
             errors << I18n.t("vagrant_aws.config.secret_access_key_required") if \
               config.secret_access_key.nil?
+          end
+
+          if config.associate_public_ip && !subnet_id
+            errors << I18n.t("vagrant_aws.config.subnet_id_required_with_public_ip")
           end
 
           errors << I18n.interpolate("vagrant_aws.config.ami_required", :region => @region)  if config.ami.nil?

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -53,6 +53,8 @@ en:
         A region must be specified via "region"
       secret_access_key_required: |-
         A secret access key is required via "secret_access_key"
+      subnet_id_required_with_public_ip: |-
+        If you assign a public IP address to an instance in a VPC, a subnet must be specifed via "subnet_id"
 
     errors:
       fog_error: |-

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -37,6 +37,7 @@ describe VagrantPlugins::AWS::Config do
     its("ssh_host_attribute") { should be_nil }
     its("monitoring")        { should == false }
     its("ebs_optimized")     { should == false }
+    its("associate_public_ip")     { should == false }
   end
 
   describe "overriding defaults" do
@@ -46,7 +47,7 @@ describe VagrantPlugins::AWS::Config do
     # and asserts the proper result comes back out.
     [:access_key_id, :ami, :availability_zone, :instance_ready_timeout,
       :instance_type, :keypair_name, :ssh_host_attribute, :ebs_optimized,
-      :region, :secret_access_key, :monitoring,
+      :region, :secret_access_key, :monitoring, :associate_public_ip,
       :subnet_id, :tags, :elastic_ip, :terminate_on_shutdown,
       :iam_instance_profile_arn, :iam_instance_profile_name,
       :use_iam_profile, :user_data, :block_device_mapping].each do |attribute|


### PR DESCRIPTION
I was implemented associate_public_ip option to assign a public IP address to an EC2 instance in a VPC.

This is for #205.

Please write Vagrantfile like this.

``` bash
Vagrant.configure("2") do |config|
  config.vm.provider :aws do |aws,override|
    aws.subnet_id = SUBNET_ID
    aws.associate_public_ip = true
  end
end
```
