### PR TITLE
Update README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `tags` - A hash of tags to set on the machine.
 * `use_iam_profile` - If true, will use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
   for credentials.
+* `block_device_mapping` - Amazon EC2 Block Device Mapping Property
 
 These can be set like typical provider-specific configuration:
 


### PR DESCRIPTION
README.md
add Configuration block_device_mapping

Amazon EC2 Block Device Mapping Property
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html
- example

``` Vagrantfile
aws.block_device_mapping = [
      {
        'DeviceName' => "/dev/sda1",
        'VirtualName' => "volume_name",
        'Ebs.VolumeSize' => 100,
        'Ebs.DeleteOnTermination' => true,
        'Ebs.VolumeType' => 'standard',
      }
    ]
```
