### PR TITLE
bugfix: per-region configs didn't work with associate_public_ip

### DIFF
--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -347,7 +347,7 @@ module VagrantPlugins
               config.secret_access_key.nil?
           end
 
-          if config.associate_public_ip && !subnet_id
+          if config.associate_public_ip && !config.subnet_id
             errors << I18n.t("vagrant_aws.config.subnet_id_required_with_public_ip")
           end
 


### PR DESCRIPTION
The construction like the following didn't work — you needed to specify subnet_id outside of region_config block

``` ruby
    aws.region_config "us-west-2" do |region|
#### skipped ####
      region.subnet_id = "subnet-0b34307f"
      region.associate_public_ip = true
    end
```
