### PR TITLE
 Elastic IP association was regularly failing after allocation.

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -209,8 +209,6 @@ module VagrantPlugins
           end
           @logger.debug("Public IP #{allocation.body['publicIp']}")
 
-          # Sleep required to correct for any potential latency from the pool of Elastic IP addresses
-          # See: https://forums.aws.amazon.com/message.jspa?messageID=471388
           sleep(180)
 
           # Associate the address and save the metadata to a hash

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -209,6 +209,8 @@ module VagrantPlugins
           end
           @logger.debug("Public IP #{allocation.body['publicIp']}")
 
+          # Sleep required to correct for any potential latency from the pool of Elastic IP addresses
+          # See: https://forums.aws.amazon.com/message.jspa?messageID=471388
           sleep(180)
 
           # Associate the address and save the metadata to a hash

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -209,6 +209,8 @@ module VagrantPlugins
           end
           @logger.debug("Public IP #{allocation.body['publicIp']}")
 
+          sleep(180)
+
           # Associate the address and save the metadata to a hash
           if domain == 'vpc'
             # VPC requires an allocation ID to assign an IP

--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-aws"
 
-  s.add_runtime_dependency "fog", "~> 1.18"
+  s.add_runtime_dependency "fog", "~> 1.22"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"


### PR DESCRIPTION
Fixes issue: https://github.com/mitchellh/vagrant-aws/issues/213

Elastic IP association now waits 180 seconds after allocation, as per recommendation from AWS support staff (See: https://forums.aws.amazon.com/message.jspa?messageID=471472)
