### PR TITLE
Fix syntax errors by inserting return characters in appropreate positions

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -114,9 +114,14 @@ module VagrantPlugins
         end
       end
 
-      def self.action_prepare_boot Vagrant::Action::Builder.new.tap do |b|
-        b.use Provision b.use SyncFolders b.use WarnNetworks b.use
-        ElbRegisterInstance end end
+      def self.action_prepare_boot
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use Provision
+          b.use SyncFolders
+          b.use WarnNetworks
+          b.use ElbRegisterInstance
+        end
+      end
 
       # This action is called to bring the box up from nothing.
       def self.action_up


### PR DESCRIPTION
I've found missing some return characters.It causes syntax error when using this plugin.
