### PR TITLE
Install rsync automatically when missing it

### DIFF
--- a/lib/vagrant-aws/action/sync_folders.rb
+++ b/lib/vagrant-aws/action/sync_folders.rb
@@ -24,9 +24,17 @@ module VagrantPlugins
 
           ssh_info = env[:machine].ssh_info
 
-          unless Vagrant::Util::Which.which('rsync')
-            env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning', :side => "host"))
-            return
+          if env[:machine].guest.capability?(:rsync_installed)
+            installed = env[:machine].guest.capability(:rsync_installed)
+            if !installed
+              can_install = env[:machine].guest.capability?(:rsync_install)
+              if !can_install
+                env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning', :side => "host"))
+                return
+              end
+              env[:machine].ui.info I18n.t("vagrant.rsync_installing")
+              env[:machine].guest.capability(:rsync_install)
+            end
           end
 
           if env[:machine].communicate.execute('which rsync', :error_check => false) != 0


### PR DESCRIPTION
I've added the function to install rsync automatically when missing it.

This code is copied from https://github.com/mitchellh/vagrant/blob/master/plugins/synced_folders/rsync/synced_folder.rb#L31 .

Code duplication is not good, but I don't know better way.Let me know if there is a better way to
do this thing.
