### PR TITLE
Removed -p switch from mkdir if communicator is WinRM

### DIFF
--- a/lib/vagrant-aws/action/sync_folders.rb
+++ b/lib/vagrant-aws/action/sync_folders.rb
@@ -67,15 +67,7 @@ module VagrantPlugins
               end
             end
 
-            # Create the guest path
-            # The -p switch is unneeded for WinRM, and fails in Powershell 4+
-            if env[:machine].config.vm.communicator == :winrm
-              env[:machine].communicate.sudo("mkdir '#{guestpath}'")
-            else
-              env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
-            end
-
-            env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
+            env[:machine].communicate.sudo(create_guest_path_command(guestpath, env[:machine].config.vm.communicator))
             env[:machine].communicate.sudo(
               "chown -R #{ssh_info[:username]} '#{guestpath}'")
 
@@ -123,6 +115,23 @@ module VagrantPlugins
           return [] unless options
 
           return options.map { |o| "-o '#{o}'" }
+        end
+
+        # Generate the command to create a filepath
+        #
+        # @param [string] path The path to create
+        # @param [string] communicator The communicator type being used (winrm, ssh)
+        # @return [string] Command to use to create the path
+        def create_guest_path_command(path, communicator)
+          # Create the guest path
+          # The -p switch is unneeded for WinRM, and fails in Powershell 4+
+          if communicator && communicator == :winrm
+            cmd = "mkdir '#{path}'"
+          else
+            cmd = "mkdir -p '#{path}'"
+          end
+
+          cmd
         end
 
         private

--- a/spec/vagrant-aws/actions/syncfolders_spec.rb
+++ b/spec/vagrant-aws/actions/syncfolders_spec.rb
@@ -25,4 +25,20 @@ describe VagrantPlugins::AWS::Action::SyncFolders do
       it { should eql ["-o 'SHKC=no'", "-o 'Port=222'"] }
     end
   end
+
+  describe '#create_guest_path_command' do
+    subject(:args) { action.create_guest_path_command(path, communicator) }
+
+    context 'communicator is not winrm' do
+      let(:path) { '/tmp2' }
+      let(:communicator) { :ssh }
+      it { should eql "mkdir -p '/tmp2'" }
+    end
+
+    context 'communicator is winrm' do
+      let(:path) { 'C:\tmp2' }
+      let(:communicator) { :winrm }
+      it { should eql "mkdir 'C:\\tmp2'" }
+    end
+  end
 end


### PR DESCRIPTION
The -p switch on mkdir in sync_folders was blowing up on a box with Powershell 4. In that version, they added a new common switch called -PipelineVariable, and it causes -p to be ambiguous. I added a check on the communicator for WinRM, and removed the switch if so. It's also not needed on previous versions of Powershell since mkdir in Powershell is recursive by default (it aliases to the New-Item cmdlet), so an additional version check is unecessary.
