### PR TITLE
add associate elastic ip support

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -201,7 +201,7 @@ module VagrantPlugins
         def do_elastic_ip(env, domain, server, elastic_ip)
           if(elastic_ip.kind_of?(String))
             association = env[:aws_compute].associate_address(server.id, elastic_ip)
-            h = { :public_ip => elastic_ip }
+            h = { :public_ip => elastic_ip, :is_ip_retain => true }
           else
             begin
               allocation = env[:aws_compute].allocate_address(domain)
@@ -221,7 +221,7 @@ module VagrantPlugins
             else
               # Standard EC2 instances only need the allocated IP address
               association = env[:aws_compute].associate_address(server.id, allocation.body['publicIp'])
-              h = { :public_ip => allocation.body['publicIp'] }
+              h = { :public_ip => allocation.body['publicIp'] ,:is_ip_retain => false }
             end
           end
 

--- a/lib/vagrant-aws/action/terminate_instance.rb
+++ b/lib/vagrant-aws/action/terminate_instance.rb
@@ -32,13 +32,17 @@ module VagrantPlugins
         # Release an elastic IP address
         def release_address(env,eip)
           h = JSON.parse(eip)
+          p h
           # Use association_id and allocation_id for VPC, use public IP for EC2
           if h['association_id']
             env[:aws_compute].disassociate_address(nil,h['association_id'])
             env[:aws_compute].release_address(h['allocation_id'])
           else
             env[:aws_compute].disassociate_address(h['public_ip'])
-            env[:aws_compute].release_address(h['public_ip'])
+            # Retain public IP
+            if(!h['is_ip_retain'])
+              env[:aws_compute].release_address(h['public_ip'])
+            end
           end
         end
       end


### PR DESCRIPTION
associate elastic ip support
after is not release elastic ip

before

```
aws.elastic_ip = true
```

after

```
aws.elastic_ip = '54.199.192.70'
```
