### PR TITLE
Update public IP setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `iam_instance_profile_name` - The name of the IAM Instance Profile to associate
   with the instance
 * `subnet_id` - The subnet to boot the instance into, for VPC.
-* `associate_public_ip` - If true, will associate a public IP address to an instance in a VPC.
+* `elastic_ip` - If true, will associate a public IP address to an instance in a VPC.
 * `tags` - A hash of tags to set on the machine.
 * `use_iam_profile` - If true, will use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
   for credentials.


### PR DESCRIPTION
Instructions should state `elastic_ip` and not `associate_public_ip`
