### PR TITLE
Bumping fog version

### DIFF
--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-aws"
 
-  s.add_runtime_dependency "fog", "~> 1.18"
+  s.add_runtime_dependency "fog", "~> 1.22"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.12.2"


### PR DESCRIPTION
Bumping fog version in an effort to keep vagrant-aws, vagrant-google, and vagrant-rackspace in sync.
