### PR TITLE
Use a new class instead of a deprecated one

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -126,7 +126,7 @@ module VagrantPlugins
       # This action is called to bring the box up from nothing.
       def self.action_up
         Vagrant::Action::Builder.new.tap do |b|
-          b.use HandleBoxUrl
+          b.use HandleBox
           b.use ConfigValidate
           b.use ConnectAWS
           b.use Call, IsCreated do |env1, b1|


### PR DESCRIPTION
Hi!

When I used vagrant-aws with the latest vagrant release v1.6.3, the following message was displayed.

```
Bringing machine 'default' up with 'aws' provider...
==> default: HandleBoxUrl middleware is deprecated. Use HandleBox instead.
==> default: This is a bug with the provider. Please contact the creator
==> default: of the provider you use to fix this.
```

I've replaced the deprecated class (HandleBoxUrl) with the new one.
