### PR TITLE
Improve documentation for aws.security_groups in a VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `secret_access_key` - The secret access key for accessing AWS
 * `security_groups` - An array of security groups for the instance. If this
   instance will be launched in VPC, this must be a list of security group
-  Name.
+  Name. For a nondefault VPC, you must use security group IDs instead (http://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html).
 * `iam_instance_profile_arn` - The Amazon resource name (ARN) of the IAM Instance
     Profile to associate with the instance
 * `iam_instance_profile_name` - The name of the IAM Instance Profile to associate


### PR DESCRIPTION
The documentation here is correct:
 http://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html

If you specify aws.subnet_id and specify a list of security group names names for aws.security_groups, then you will get the following error message:

==> default: Launching an instance with the following settings...
==> default:  -- Security Groups: ["A","B"]
...
==> default:  -- Assigning a public IP address in a VPC: false
There was an error talking to AWS. The error message is shown
below:

InvalidParameterCombination => The parameter groupName cannot be used with the parameter subnet

If you specify aws.subnet_id and specify a list of security group IDs names for aws.security_groups, then this plugin works:

==> default: Launching an instance with the following settings...
==> default:  -- Security Groups: ["sg-1234","sg-4567"]
...
==> default:  -- Assigning a public IP address in a VPC: false
==> default: Waiting for instance to become "ready"...
==> default: Waiting for SSH to become available...
==> default: Machine is booted and ready for use!

See people talking about this here:
http://stackoverflow.com/questions/22365470/launching-instance-vpc-security-groups-may-not-be-used-for-a-non-vpc-launch
