### PR TITLE
Update README to clarify rsync exclusion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ the remote machine over SSH.
 This is good enough for all built-in Vagrant provisioners (shell,
 chef, and puppet) to work!
 
-To exclude files or directories from rsync, use the `rsync_excludes` option. For example, to exclude the "env" directory:
+To exclude files or directories from rsync, use the `rsync_excludes` option. For example, to exclude the "bar" and "foo" directories:
 
 ```ruby
 Vagrant.configure("2") do |config|
   # ... other stuff
 
-  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync_excludes: "env/"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", :rsync_excludes => ['bar/', 'foo/']
 end
 ```
 


### PR DESCRIPTION
I propose clarifying issue #232 via the README.  The current exclusion option differs from that listed here: https://docs.vagrantup.com/v2/synced-folders/rsync.html

Thanks!
mypetyak
