### PR TITLE
m1.small has been deprecated in us-east-1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ This provider exposes quite a few provider-specific configuration options:
   the instance. If nil, it will use the default set by Amazon.
 * `instance_ready_timeout` - The number of seconds to wait for the instance
   to become "ready" in AWS. Defaults to 120 seconds.
-* `instance_type` - The type of instance, such as "m1.small". The default
-  value of this if not specified is "m1.small".
+* `instance_type` - The type of instance, such as "m3.medium". The default
+  value of this if not specified is "m3.medium".  "m1.small" has been
+  deprecated in "us-east-1" and "m3.medium" is the smallest instance
+  type to support both paravirtualization and hvm AMIs
 * `keypair_name` - The name of the keypair to use to bootstrap AMIs
    which support it.
 * `private_ip_address` - The private IP address to assign to an instance

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
       # @return [Fixnum]
       attr_accessor :instance_ready_timeout
 
-      # The type of instance to launch, such as "m1.small"
+      # The type of instance to launch, such as "m3.medium"
       #
       # @return [String]
       attr_accessor :instance_type
@@ -255,8 +255,8 @@ module VagrantPlugins
         # Set the default timeout for waiting for an instance to be ready
         @instance_ready_timeout = 120 if @instance_ready_timeout == UNSET_VALUE
 
-        # Default instance type is an m1.small
-        @instance_type = "m1.small" if @instance_type == UNSET_VALUE
+        # Default instance type is an m3.medium
+        @instance_type = "m3.medium" if @instance_type == UNSET_VALUE
 
         # Keypair defaults to nil
         @keypair_name = nil if @keypair_name == UNSET_VALUE

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -19,7 +19,7 @@ describe VagrantPlugins::AWS::Config do
     its("ami")               { should be_nil }
     its("availability_zone") { should be_nil }
     its("instance_ready_timeout") { should == 120 }
-    its("instance_type")     { should == "m1.small" }
+    its("instance_type")     { should == "m3.medium" }
     its("keypair_name")      { should be_nil }
     its("private_ip_address") { should be_nil }
     its("region")            { should == "us-east-1" }


### PR DESCRIPTION
m1.small has been deprecated in us-east-1 for newly created instances. Although the t-class instance types are less expensive, they only support hvm AMIs.  The m3.medium instance type is the smallest instance type to support both paravirtualization and hvm AMIs.
