### PR TITLE
remove :endpoint option from fog elb config

### DIFF
--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
 
           @logger.info("Connecting to AWS...")
           env[:aws_compute] = Fog::Compute.new(fog_config)
-          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.except(:provider))
+          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.except(:provider, :endpoint))
 
           @app.call(env)
         end


### PR DESCRIPTION
When specifically setting an ec2 endpoint fog prints a warning when initializing the
`Fog::AWS::ELB` driver:

```
[fog][WARNING] Unrecognized arguments: endpoint
```
