### PR TITLE
Added retry delay when creating instances.

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -132,7 +132,7 @@ module VagrantPlugins
                 next if env[:interrupted]
 
                 # Wait for the server to be ready
-                server.wait_for(2) { ready? }
+                server.wait_for(2, 5) { ready? }
               end
             rescue Fog::Errors::TimeoutError
               # Delete the instance


### PR DESCRIPTION
Without a retry delay - if you configure a lot of servers at the same time you will run into AWS API limits and it will throw an exception that will stop instance creation.

This adds in a minor delay when checking the status of an instance which seems to fix the issue when deploying ~ 20 - 40 machines.
