### PR TITLE
Check for outdated boxes on vagrant up

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -143,6 +143,7 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use HandleBox
           b.use ConfigValidate
+          b.use BoxCheckOutdated
           b.use ConnectAWS
           b.use Call, IsCreated do |env1, b1|
             if env1[:result]


### PR DESCRIPTION
Ensure that outdated boxes generate warnings if the auto check is enabled.
