### PR TITLE
Fix deprecated RSpec methods

### DIFF
--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -1,4 +1,5 @@
 require "vagrant-aws/config"
+require 'rspec/its'
 
 describe VagrantPlugins::AWS::Config do
   let(:instance) { described_class.new }
@@ -32,7 +33,7 @@ describe VagrantPlugins::AWS::Config do
     its("iam_instance_profile_name") { should be_nil }
     its("tags")              { should == {} }
     its("user_data")         { should be_nil }
-    its("use_iam_profile")   { should be_false }
+    its("use_iam_profile")   { should be false }
     its("block_device_mapping")  {should == [] }
     its("elastic_ip")        { should be_nil }
     its("terminate_on_shutdown") { should == false }


### PR DESCRIPTION
When I ran `rake spec`, I got these warnings.

```
Deprecation Warnings:

Use of rspec-core's `its` method is deprecated. Use the rspec-its gem instead. Called from /private/var/workspace/vagrant/vagrant-aws/spec/vagrant-aws/config_spec.rb:18:in `block (2 levels) in <top (required)>'.
Use of rspec-core's `its` method is deprecated. Use the rspec-its gem instead. Called from /private/var/workspace/vagrant/vagrant-aws/spec/vagrant-aws/config_spec.rb:19:in `block (2 levels) in <top (required)>'.
Use of rspec-core's `its` method is deprecated. Use the rspec-its gem instead. Called from /private/var/workspace/vagrant/vagrant-aws/spec/vagrant-aws/config_spec.rb:20:in `block (2 levels) in <top (required)>'.
Too many uses of deprecated 'Use of rspec-core's `its` method'. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output

`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional semantics) or `be false` (for exact `== false` equality) instead. Called from /private/var/workspace/vagrant/vagrant-aws/spec/vagrant-aws/config_spec.rb:36:in `block (3 levels) in <top (required)>'.
```

`rspec-its` is already part of gemspec, so I only used it.