### PR TITLE
Add support for credentials file (WIP)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'aws-sdk', '~> 1.60.2'
+
 group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -73,6 +73,12 @@ en:
         A secret access key is required via "secret_access_key"
       subnet_id_required_with_public_ip: |-
         If you assign a public IP address to an instance in a VPC, a subnet must be specifed via "subnet_id"
+      access_key_id_cred_path_conflict: |-
+        Either "access_key_id" or "credential_file" must be specifed, not both
+      secret_access_key_cred_path_conflict: |-
+        Either "secret_access_key" or "credential_file" must be specifed, not both
+      session_token_cred_path_conflict: |-
+        Either "session_token" or "credential_file" must be specifed, not both
 
     errors:
       fog_error: |-


### PR DESCRIPTION
This is adding support for new config option `credential_file` as discussed earlier in https://github.com/mitchellh/vagrant-aws/issues/151 and https://github.com/mitchellh/vagrant-aws/issues/15#issuecomment-16144513

I tried to implement it exactly the way @mitchellh described in https://github.com/mitchellh/vagrant-aws/issues/15#issuecomment-16144513 and it basically works except that I probably didn't fully understand the lifecycle - when `finalize!` & `validate` gets called, which is why the validation is broken and always assumes conflict.

Maybe I can move the whole block in `finalize` somewhere else, so it gets executed after `validate`?

Also there's one more config option that can be added, `profile` defaulting to `ENV['AWS_PROFILE']`:
https://github.com/aws/aws-sdk-ruby/blob/master/spec/aws/core/credential_providers_spec.rb#L395

Here's an example of `AWS_PROFILE` variable name use (just FYI, that I'm not reinventing the wheel here):
https://github.com/aws/aws-sdk-core-ruby/blob/90f34bcb002ef8be418502164063fe297727f9d5/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb#L13-14

Here's an example of how the generated ini file may look like:
https://github.com/aws/aws-cli/blob/master/README.rst#getting-started