### PR TITLE
Do not sync folders during a vagrant provision

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -73,7 +73,6 @@ module VagrantPlugins
             end
 
             b2.use Provision
-            b2.use SyncedFolders
           end
         end
       end


### PR DESCRIPTION
According to https://docs.vagrantup.com/v2/synced-folders/rsync.html:

> Vagrant only syncs the folders on vagrant up or vagrant reload.