### PR TITLE
changed the order of the target properties for ssh. 

### DIFF
--- a/lib/vagrant-aws/action/read_ssh_info.rb
+++ b/lib/vagrant-aws/action/read_ssh_info.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
           ssh_host_attribute = machine.provider_config.
               get_region_config(machine.provider_config.region).ssh_host_attribute
           # default host attributes to try. NOTE: Order matters!
-          ssh_attrs = [:public_ip_address, :dns_name, :private_ip_address]
+          ssh_attrs = [:dns_name, :public_ip_address, :private_ip_address]
           ssh_attrs = (Array(ssh_host_attribute) + ssh_attrs).uniq if ssh_host_attribute
           # try each attribute, get out on first value
           host_value = nil


### PR DESCRIPTION
This PR changes the order of the target properties for connecting via SSH. The code was originally using public IP first if found. It is more efficient to use public DNS because by design ec2 will return the public IP if the DNS request comes from outside and it will return the private ip if the request comes from inside ec2. This helps organization that a very lock down access to instances and only allow access either via a bastion or vpn device. Although some of the subnets are private and will only have private ip, other subnets are public (with internet access) but are still locked down to prevent public ssh access. 

With this change the code will check first for the public dns and if found use that. If not it will go to the public ip and then private 