### PR TITLE
Add support for 'tenancy' option when launching VPC instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This provider exposes quite a few provider-specific configuration options:
   with the instance
 * `subnet_id` - The subnet to boot the instance into, for VPC.
 * `associate_public_ip` - If true, will associate a public IP address to an instance in a VPC.
+* `tenancy` - When running in a VPC configure the tenancy of the instance.  Supports 'default' and 'dedicated'.
 * `tags` - A hash of tags to set on the machine.
 * `package_tags` - A hash of tags to set on the ami generated during the package operation.
 * `use_iam_profile` - If true, will use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -43,6 +43,7 @@ module VagrantPlugins
           monitoring            = region_config.monitoring
           ebs_optimized         = region_config.ebs_optimized
           associate_public_ip   = region_config.associate_public_ip
+          tenancy               = region_config.tenancy
 
           # If there is no keypair then warn the user
           if !keypair
@@ -74,6 +75,7 @@ module VagrantPlugins
           env[:ui].info(" -- Monitoring: #{monitoring}")
           env[:ui].info(" -- EBS optimized: #{ebs_optimized}")
           env[:ui].info(" -- Assigning a public IP address in a VPC: #{associate_public_ip}")
+          env[:ui].info(" -- VPC tenancy specification: #{tenancy}")
 
           options = {
             :availability_zone         => availability_zone,
@@ -90,7 +92,8 @@ module VagrantPlugins
             :instance_initiated_shutdown_behavior => terminate_on_shutdown == true ? "terminate" : nil,
             :monitoring                => monitoring,
             :ebs_optimized             => ebs_optimized,
-            :associate_public_ip        => associate_public_ip
+            :associate_public_ip       => associate_public_ip,
+            :tenancy                   => tenancy
           }
           if !security_groups.empty?
             security_group_key = options[:subnet_id].nil? ? :groups : :security_group_ids

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -160,6 +160,12 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :elb
 
+      # The tenancy of the instance in a VPC.
+      # Defaults to 'default'.
+      #
+      # @return [String]
+      attr_accessor :tenancy
+
       def initialize(region_specific=false)
         @access_key_id             = UNSET_VALUE
         @ami                       = UNSET_VALUE
@@ -190,6 +196,7 @@ module VagrantPlugins
         @ebs_optimized             = UNSET_VALUE
         @associate_public_ip       = UNSET_VALUE
         @elb                       = UNSET_VALUE
+        @tenancy                   = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -338,6 +345,9 @@ module VagrantPlugins
 
         # default false
         @associate_public_ip = false if @associate_public_ip == UNSET_VALUE
+
+        # default 'default'
+        @tenancy = "default" if @tenancy == UNSET_VALUE
 
         # Don't attach instance to any ELB by default
         @elb = nil if @elb == UNSET_VALUE

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -42,6 +42,7 @@ describe VagrantPlugins::AWS::Config do
     its("monitoring")        { should == false }
     its("ebs_optimized")     { should == false }
     its("associate_public_ip")     { should == false }
+    its("tenancy")     { should == "default" }
   end
 
   describe "overriding defaults" do


### PR DESCRIPTION
Add support for passing through the 'tenancy' option to fog when launching new VPC instances.

The request for this functionality was also made in #375 