### PR TITLE
Enabled the option to specify the Source/Destination checks flag

### DIFF
--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -154,6 +154,11 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :ebs_optimized
 
+      # Source Destination check
+      #
+      # @return [Boolean]
+      attr_accessor :source_dest_check
+
       # Assigning a public IP address in a VPC
       #
       # @return [Boolean]
@@ -204,6 +209,7 @@ module VagrantPlugins
         @ssh_host_attribute        = UNSET_VALUE
         @monitoring                = UNSET_VALUE
         @ebs_optimized             = UNSET_VALUE
+        @source_dest_check         = UNSET_VALUE
         @associate_public_ip       = UNSET_VALUE
         @elb                       = UNSET_VALUE
         @unregister_elb_from_az       = UNSET_VALUE
@@ -356,6 +362,9 @@ module VagrantPlugins
 
         # default false
         @ebs_optimized = false if @ebs_optimized == UNSET_VALUE
+
+        # default to nil
+        @source_dest_check = nil if @source_dest_check == UNSET_VALUE
 
         # default false
         @associate_public_ip = false if @associate_public_ip == UNSET_VALUE

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -39,6 +39,9 @@ en:
       Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
+    source_dest_checks_no_vpc: |-
+      Warning! Ignoring source_dest_checks flag as it can only be configured on
+      a VPC instance.
     starting: |-
       Starting the instance...
     stopping: |-

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -42,6 +42,7 @@ describe VagrantPlugins::AWS::Config do
     its("ssh_host_attribute") { should be_nil }
     its("monitoring")        { should == false }
     its("ebs_optimized")     { should == false }
+    its("source_dest_check")       { should be_nil }
     its("associate_public_ip")     { should == false }
     its("unregister_elb_from_az") { should == true }
   end
@@ -56,7 +57,8 @@ describe VagrantPlugins::AWS::Config do
       :ebs_optimized, :region, :secret_access_key, :session_token, :monitoring,
       :associate_public_ip, :subnet_id, :tags, :package_tags, :elastic_ip,
       :terminate_on_shutdown, :iam_instance_profile_arn, :iam_instance_profile_name,
-      :use_iam_profile, :user_data, :block_device_mapping].each do |attribute|
+      :use_iam_profile, :user_data, :block_device_mapping,
+      :source_dest_check].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
         instance.send("#{attribute}=".to_sym, "foo")


### PR DESCRIPTION
This patch enables the option to set the source/destination checks flag
on an amazon vpc instance. This flag cannot be set while creating the
instance so an additional call is required.