### PR TITLE
Patch for https://github.com/mitchellh/vagrant-aws/issues/250

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # editors
 *.swp
-.idea
 
 # Bundler/Rubygems
 *.gem

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # editors
 *.swp
+.idea
 
 # Bundler/Rubygems
 *.gem

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This provider exposes quite a few provider-specific configuration options:
   for credentials.
 * `block_device_mapping` - Amazon EC2 Block Device Mapping Property
 * `elb` - The ELB name to attach to the instance.
-* `unregisterElbFromAz` - Removes the ELB from the AZ on removal of the last instance if true (default). In non default VPC this has to be false.
+* `unregister_ELB_from_Az` - Removes the ELB from the AZ on removal of the last instance if true (default). In non default VPC this has to be false.
 * `terminate_on_shutdown` - Indicates whether an instance stops or terminates
   when you initiate shutdown from the instance.
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This provider exposes quite a few provider-specific configuration options:
   for credentials.
 * `block_device_mapping` - Amazon EC2 Block Device Mapping Property
 * `elb` - The ELB name to attach to the instance.
-* `unregister_ELB_from_Az` - Removes the ELB from the AZ on removal of the last instance if true (default). In non default VPC this has to be false.
+* `unregister_elb_from_az` - Removes the ELB from the AZ on removal of the last instance if true (default). In non default VPC this has to be false.
 * `terminate_on_shutdown` - Indicates whether an instance stops or terminates
   when you initiate shutdown from the instance.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This provider exposes quite a few provider-specific configuration options:
   for credentials.
 * `block_device_mapping` - Amazon EC2 Block Device Mapping Property
 * `elb` - The ELB name to attach to the instance.
+* `unregisterElbFromAz` - Removes the ELB from the AZ on removal of the last instance if true (default). In non default VPC this has to be false.
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -348,7 +348,7 @@ module VagrantPlugins
         # Don't attach instance to any ELB by default
         @elb = nil if @elb == UNSET_VALUE
 
-        @unregisterELBFromAz = true if @unregisterELBFromAz == UNSET_VALUE
+        @unregister_ELB_from_Az = true if @unregister_ELB_from_Az == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -160,6 +160,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :elb
 
+      # Disable unregisering ELB's from AZ - useful in case of not using default VPC
+      # @return [Boolean]
+      attr_accessor :unregisterELBFromAz
+
+
       def initialize(region_specific=false)
         @access_key_id             = UNSET_VALUE
         @ami                       = UNSET_VALUE
@@ -190,6 +195,7 @@ module VagrantPlugins
         @ebs_optimized             = UNSET_VALUE
         @associate_public_ip       = UNSET_VALUE
         @elb                       = UNSET_VALUE
+        @unregisterELBFromAz       = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -341,6 +347,8 @@ module VagrantPlugins
 
         # Don't attach instance to any ELB by default
         @elb = nil if @elb == UNSET_VALUE
+
+        @unregisterELBFromAz = true if @unregisterELBFromAz == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -162,7 +162,7 @@ module VagrantPlugins
 
       # Disable unregisering ELB's from AZ - useful in case of not using default VPC
       # @return [Boolean]
-      attr_accessor :unregister_ELB_from_Az
+      attr_accessor :unregister_elb_from_az
 
       # Kernel Id
       #
@@ -200,7 +200,7 @@ module VagrantPlugins
         @ebs_optimized             = UNSET_VALUE
         @associate_public_ip       = UNSET_VALUE
         @elb                       = UNSET_VALUE
-        @unregister_ELB_from_Az       = UNSET_VALUE
+        @unregister_elb_from_az       = UNSET_VALUE
         @kernel_id                 = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
@@ -354,7 +354,7 @@ module VagrantPlugins
         # Don't attach instance to any ELB by default
         @elb = nil if @elb == UNSET_VALUE
 
-        @unregister_ELB_from_Az = true if @unregister_ELB_from_Az == UNSET_VALUE
+        @unregister_elb_from_az = true if @unregister_elb_from_az == UNSET_VALUE
 
         # default to nil
         @kernel_id = nil if @kernel_id == UNSET_VALUE

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -162,7 +162,7 @@ module VagrantPlugins
 
       # Disable unregisering ELB's from AZ - useful in case of not using default VPC
       # @return [Boolean]
-      attr_accessor :unregisterELBFromAz
+      attr_accessor :unregister_ELB_from_Az
 
 
       def initialize(region_specific=false)
@@ -195,7 +195,7 @@ module VagrantPlugins
         @ebs_optimized             = UNSET_VALUE
         @associate_public_ip       = UNSET_VALUE
         @elb                       = UNSET_VALUE
-        @unregisterELBFromAz       = UNSET_VALUE
+        @unregister_ELB_from_Az       = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)

--- a/lib/vagrant-aws/util/elb.rb
+++ b/lib/vagrant-aws/util/elb.rb
@@ -20,7 +20,9 @@ module VagrantPlugins
         if elb.instances.include? instance_id
           elb.deregister_instances([instance_id])
           env[:ui].info I18n.t("vagrant_aws.elb.ok"), :prefix => false
-          adjust_availability_zones env, elb
+          if env[:unregisterELBFromAz]
+            adjust_availability_zones env, elb
+          end
         else
           env[:ui].info I18n.t("vagrant_aws.elb.skipped"), :prefix => false
         end

--- a/lib/vagrant-aws/util/elb.rb
+++ b/lib/vagrant-aws/util/elb.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
         if elb.instances.include? instance_id
           elb.deregister_instances([instance_id])
           env[:ui].info I18n.t("vagrant_aws.elb.ok"), :prefix => false
-          if env[:machine].provider_config.unregister_ELB_from_Az
+          if env[:machine].provider_config.unregister_elb_from_az
             adjust_availability_zones env, elb
           end
         else

--- a/lib/vagrant-aws/util/elb.rb
+++ b/lib/vagrant-aws/util/elb.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
         if elb.instances.include? instance_id
           elb.deregister_instances([instance_id])
           env[:ui].info I18n.t("vagrant_aws.elb.ok"), :prefix => false
-          if env[:unregisterELBFromAz]
+          if env[:machine].provider_config.unregister_ELB_from_Az
             adjust_availability_zones env, elb
           end
         else

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -42,7 +42,7 @@ describe VagrantPlugins::AWS::Config do
     its("monitoring")        { should == false }
     its("ebs_optimized")     { should == false }
     its("associate_public_ip")     { should == false }
-    its("unregister_ELB_from_Az") { should == true }
+    its("unregister_elb_from_az") { should == true }
   end
 
   describe "overriding defaults" do

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -42,7 +42,7 @@ describe VagrantPlugins::AWS::Config do
     its("monitoring")        { should == false }
     its("ebs_optimized")     { should == false }
     its("associate_public_ip")     { should == false }
-    its("unregisterELBFromAz") { should == true }
+    its("unregister_ELB_from_Az") { should == true }
   end
 
   describe "overriding defaults" do

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -42,6 +42,7 @@ describe VagrantPlugins::AWS::Config do
     its("monitoring")        { should == false }
     its("ebs_optimized")     { should == false }
     its("associate_public_ip")     { should == false }
+    its("unregisterELBFromAz") { should == true }
   end
 
   describe "overriding defaults" do


### PR DESCRIPTION
This patch adds an extra configuration parameter for https://github.com/mitchellh/vagrant-aws/issues/250 which occurs when using the non-default VPC reliably for our deployments.

The default behaviour remains as is, but adding the additional flag prevents the de-register which allows the destroy phase to succeed.