### PR TITLE
Adding state check interval to start_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+* Added configurable instance state check interval
+
 # 0.6.0 (December 13, 2014)
 
 * Support static Elastic IP addresses.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ This provider exposes quite a few provider-specific configuration options:
   the instance. If nil, it will use the default set by Amazon.
 * `instance_ready_timeout` - The number of seconds to wait for the instance
   to become "ready" in AWS. Defaults to 120 seconds.
+* `instance_check_interval` - The number of seconds to wait to check the instance's
+ state
 * `instance_package_timeout` - The number of seconds to wait for the instance
   to be burnt into an AMI during packaging. Defaults to 600 seconds.
 * `instance_type` - The type of instance, such as "m3.medium". The default

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -133,7 +133,7 @@ module VagrantPlugins
                 next if env[:interrupted]
 
                 # Wait for the server to be ready
-                server.wait_for(2, 5) { ready? }
+                server.wait_for(2, region_config.instance_check_interval) { ready? }
               end
             rescue Fog::Errors::TimeoutError
               # Delete the instance

--- a/lib/vagrant-aws/action/start_instance.rb
+++ b/lib/vagrant-aws/action/start_instance.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
 
             # Wait for the instance to be ready first
             env[:metrics]["instance_ready_time"] = Util::Timer.time do
-                tries = region_config.instance_ready_timeout / region_config.instance_check_interval
+                tries = region_config.instance_ready_timeout / 2
 
               env[:ui].info(I18n.t("vagrant_aws.waiting_for_ready"))
               begin
@@ -41,7 +41,7 @@ module VagrantPlugins
                   next if env[:interrupted]
 
                   # Wait for the server to be ready
-                  server.wait_for(region_config.instance_check_interval) { ready? }
+                  server.wait_for(2) { ready? }
                 end
               rescue Fog::Errors::TimeoutError
                 # Notify the user

--- a/lib/vagrant-aws/action/start_instance.rb
+++ b/lib/vagrant-aws/action/start_instance.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
 
             # Wait for the instance to be ready first
             env[:metrics]["instance_ready_time"] = Util::Timer.time do
-              tries = region_config.instance_ready_timeout / 2
+                tries = region_config.instance_ready_timeout / region_config.instance_check_interval
 
               env[:ui].info(I18n.t("vagrant_aws.waiting_for_ready"))
               begin
@@ -41,7 +41,7 @@ module VagrantPlugins
                   next if env[:interrupted]
 
                   # Wait for the server to be ready
-                  server.wait_for(2) { ready? }
+                  server.wait_for(region_config.instance_check_interval) { ready? }
                 end
               rescue Fog::Errors::TimeoutError
                 # Notify the user

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -24,6 +24,11 @@ module VagrantPlugins
       # @return [Fixnum]
       attr_accessor :instance_ready_timeout
 
+      # The interval to wait for checking an instance's state.
+      #
+      # @return [Fixnum]
+      attr_accessor :instance_check_interval
+
       # The timeout to wait for an instance to successfully burn into an AMI.
       #
       # @return [Fixnum]
@@ -170,6 +175,7 @@ module VagrantPlugins
         @access_key_id             = UNSET_VALUE
         @ami                       = UNSET_VALUE
         @availability_zone         = UNSET_VALUE
+        @instance_check_interval   = UNSET_VALUE
         @instance_ready_timeout    = UNSET_VALUE
         @instance_package_timeout  = UNSET_VALUE
         @instance_type             = UNSET_VALUE
@@ -292,6 +298,9 @@ module VagrantPlugins
 
         # Set the default timeout for waiting for an instance to be ready
         @instance_ready_timeout = 120 if @instance_ready_timeout == UNSET_VALUE
+
+        # Set the default interval to check instance state
+        @instance_check_interval = 2 if @instance_check_interval == UNSET_VALUE
 
         # Set the default timeout for waiting for an instance to burn into and ami
         @instance_package_timeout = 600 if @instance_package_timeout == UNSET_VALUE

--- a/lib/vagrant-aws/version.rb
+++ b/lib/vagrant-aws/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module AWS
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -20,6 +20,7 @@ describe VagrantPlugins::AWS::Config do
     its("ami")               { should be_nil }
     its("availability_zone") { should be_nil }
     its("instance_ready_timeout") { should == 120 }
+    its("instance_check_interval") { should == 2 }
     its("instance_package_timeout") { should == 600 }
     its("instance_type")     { should == "m3.medium" }
     its("keypair_name")      { should be_nil }


### PR DESCRIPTION
This adds a much requested feature to be able to configure the interval that vagrant checks AWS for instance state during luanch