### PR TITLE
Add support for 'tenancy' option when launching VPC instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This provider exposes quite a few provider-specific configuration options:
   connection issues if, e.g., you are assigning a public IP address but your
   security groups prevent public SSH access and require you to SSH in via the
   private IP address; specify `:private_ip_address` in this case.
+* `tenancy` - When running in a VPC configure the tenancy of the instance.  Supports 'default' and 'dedicated'.
 * `tags` - A hash of tags to set on the machine.
 * `package_tags` - A hash of tags to set on the ami generated during the package operation.
 * `use_iam_profile` - If true, will use [IAM profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -45,6 +45,7 @@ module VagrantPlugins
           source_dest_check     = region_config.source_dest_check
           associate_public_ip   = region_config.associate_public_ip
           kernel_id             = region_config.kernel_id
+          tenancy               = region_config.tenancy
 
           # If there is no keypair then warn the user
           if !keypair
@@ -77,6 +78,7 @@ module VagrantPlugins
           env[:ui].info(" -- EBS optimized: #{ebs_optimized}")
           env[:ui].info(" -- Source Destination check: #{source_dest_check}")
           env[:ui].info(" -- Assigning a public IP address in a VPC: #{associate_public_ip}")
+          env[:ui].info(" -- VPC tenancy specification: #{tenancy}")
 
           options = {
             :availability_zone         => availability_zone,
@@ -95,8 +97,10 @@ module VagrantPlugins
             :ebs_optimized             => ebs_optimized,
             :associate_public_ip       => associate_public_ip,
             :kernel_id                 => kernel_id,
-            :associate_public_ip       => associate_public_ip
+            :associate_public_ip       => associate_public_ip,
+            :tenancy                   => tenancy
           }
+
           if !security_groups.empty?
             security_group_key = options[:subnet_id].nil? ? :groups : :security_group_ids
             options[security_group_key] = security_groups

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -179,6 +179,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :kernel_id
 
+      # The tenancy of the instance in a VPC.
+      # Defaults to 'default'.
+      #
+      # @return [String]
+      attr_accessor :tenancy
 
       def initialize(region_specific=false)
         @access_key_id             = UNSET_VALUE
@@ -212,8 +217,9 @@ module VagrantPlugins
         @source_dest_check         = UNSET_VALUE
         @associate_public_ip       = UNSET_VALUE
         @elb                       = UNSET_VALUE
-        @unregister_elb_from_az       = UNSET_VALUE
+        @unregister_elb_from_az    = UNSET_VALUE
         @kernel_id                 = UNSET_VALUE
+        @tenancy                   = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -368,6 +374,9 @@ module VagrantPlugins
 
         # default false
         @associate_public_ip = false if @associate_public_ip == UNSET_VALUE
+
+        # default 'default'
+        @tenancy = "default" if @tenancy == UNSET_VALUE
 
         # Don't attach instance to any ELB by default
         @elb = nil if @elb == UNSET_VALUE

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -45,6 +45,7 @@ describe VagrantPlugins::AWS::Config do
     its("source_dest_check")       { should be_nil }
     its("associate_public_ip")     { should == false }
     its("unregister_elb_from_az") { should == true }
+    its("tenancy")     { should == "default" }
   end
 
   describe "overriding defaults" do


### PR DESCRIPTION
This is just a rebase of #395 

Fixes #375
Fixes #395