### PR TITLE
Spot Instances, includes tagging and EBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ EC2 and VPC.
 * Define region-specific configurations so Vagrant can manage machines
   in multiple regions.
 * Package running instances into new vagrant-aws friendly boxes
+* Spot Instance Support
 
 ## Usage
 
@@ -153,6 +154,10 @@ This provider exposes quite a few provider-specific configuration options:
 * `unregister_elb_from_az` - Removes the ELB from the AZ on removal of the last instance if true (default). In non default VPC this has to be false.
 * `terminate_on_shutdown` - Indicates whether an instance stops or terminates
   when you initiate shutdown from the instance.
+  
+* `spot_instance` - Boolean value; indicates whether the config is for a spot instance, or on-demand. For more information about spot instances, see the [AWS Documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-spot-instances-work.html)
+* `max_spot_price` - Decimal value; state the maximum bid for your spot instance. Ignored if `spot_instance` is not true.
+* `spot_valid_until` - Timestamp; when this spot instance request should expire, destroying any related instances. Ignored if `spot_instance` is not true.
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -129,6 +129,21 @@ module VagrantPlugins
       # @return [Array<Hash>]
       attr_accessor :block_device_mapping
 
+      # Launch as spot instance
+      #
+      # @return [Boolean]
+      attr_accessor :spot_instance
+
+      # Spot request max price
+      #
+      # @return [String]
+      attr_accessor :spot_max_price
+
+      # Spot request validity
+      #
+      # @return [Time]
+      attr_accessor :spot_valid_until
+
       # Indicates whether an instance stops or terminates when you initiate shutdown from the instance
       #
       # @return [bool]
@@ -207,6 +222,9 @@ module VagrantPlugins
         @user_data                 = UNSET_VALUE
         @use_iam_profile           = UNSET_VALUE
         @block_device_mapping      = []
+        @spot_instance             = UNSET_VALUE
+        @spot_max_price            = UNSET_VALUE
+        @spot_valid_until          = UNSET_VALUE
         @elastic_ip                = UNSET_VALUE
         @iam_instance_profile_arn  = UNSET_VALUE
         @iam_instance_profile_name = UNSET_VALUE
@@ -357,6 +375,15 @@ module VagrantPlugins
         # User Data is nil by default
         @user_data = nil if @user_data == UNSET_VALUE
 
+        # By default don't use spot requests
+        @spot_instance = false if @spot_instance == UNSET_VALUE
+
+        # Required, no default
+        @spot_max_price = nil if @spot_max_price == UNSET_VALUE
+
+        # Default: Request is effective indefinitely.
+        @spot_valid_until = nil if @spot_valid_until == UNSET_VALUE
+
         # default false
         @terminate_on_shutdown = false if @terminate_on_shutdown == UNSET_VALUE
 
@@ -433,6 +460,7 @@ module VagrantPlugins
           end
 
           errors << I18n.t("vagrant_aws.config.ami_required", :region => @region)  if config.ami.nil?
+          errors << I18n.t("vagrant_aws.config.spot_price_required") if config.spot_instance && config.spot_max_price.nil?
         end
 
         { "AWS Provider" => errors }

--- a/lib/vagrant-aws/version.rb
+++ b/lib/vagrant-aws/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module AWS
-    VERSION = '0.6.1'
+    VERSION = '0.6.2'
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -18,6 +18,8 @@ en:
 
     launching_instance: |-
       Launching an instance with the following settings...
+    launching_spot_instance: |-
+      Launching a spot request instance with the following settings...
     launch_no_keypair: |-
       Warning! You didn't specify a keypair to launch your instance with.
       This can sometimes result in not being able to access your instance.
@@ -68,6 +70,8 @@ en:
         An access key ID must be specified via "access_key_id"
       ami_required: |-
         An AMI must be configured via "ami" (region: #{region})
+      spot_price_required: |-
+        Spot request is missing "spot_max_price"
       private_key_missing: |-
         The specified private key for AWS could not be found
       region_required: |-

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -37,6 +37,9 @@ describe VagrantPlugins::AWS::Config do
     its("user_data")         { should be_nil }
     its("use_iam_profile")   { should be false }
     its("block_device_mapping")  {should == [] }
+    its("spot_instance")     { should be_false }
+    its("spot_max_price")    { should be_nil }
+    its("spot_valid_until")  { should be_nil }
     its("elastic_ip")        { should be_nil }
     its("terminate_on_shutdown") { should == false }
     its("ssh_host_attribute") { should be_nil }


### PR DESCRIPTION
Forked original vagrant-aws repo to be able to submit pull request.

Added code changes from https://github.com/3vcloud/vagrant-aws , thanks to https://github.com/KariusDx/vagrant-aws for original spot functionality.

This commit allows spot instances to be created; the process in synchronous - waiting for the spot request to be successful before continuing. Cancels spot request after server is up.