### PR TITLE
Prevent "Unrecognized arguments: version" Fog warning when specifying region.version

### DIFF
--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
           @logger.info("Connecting to AWS...")
           env[:aws_compute] = Fog::Compute.new(fog_config)
-          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.except(:provider, :endpoint))
+          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.except(:provider, :endpoint, :version))
 
           @app.call(env)
         end


### PR DESCRIPTION
The :version argument is not recognized by the Fog::AWS::ELB service