### PR TITLE
Add support for AWS config and credential files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", :git => "https://github.com/mitchellh/vagrant.git"
-  gem 'iniparse', '~> 1.4', '>= 1.4.2'
 end
 
 group :plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem "vagrant", :git => "https://github.com/mitchellh/vagrant.git"
+  gem 'iniparse', '~> 1.4', '>= 1.4.2'
 end
 
 group :plugins do

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ no preconfigured defaults.
 If you have issues with SSH connecting, make sure that the instances
 are being launched with a security group that allows SSH access.
 
+Note: if you don't configure `aws.access_key_id` or `aws_secret_access_key`
+it will attempt to read credentials from environment variables first and then
+from `$HOME/.aws/`. You can choose your AWS profile and files location by using
+`aws.aws_profile` and `aws.aws_dir`.
+
 ## Box Format
 
 Every provider in Vagrant must introduce a custom box format. This
@@ -106,6 +111,8 @@ This provider exposes quite a few provider-specific configuration options:
 * `ami` - The AMI id to boot, such as "ami-12345678"
 * `availability_zone` - The availability zone within the region to launch
   the instance. If nil, it will use the default set by Amazon.
+* `aws_profile` - AWS profile in your config files. Defaults to *default*.
+* `aws_dir` - AWS config and credentials location. Defaults to *$HOME/.aws/*.
 * `instance_ready_timeout` - The number of seconds to wait for the instance
   to become "ready" in AWS. Defaults to 120 seconds.
 * `instance_check_interval` - The number of seconds to wait to check the instance's

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ it will attempt to read credentials from environment variables first and then
 from `$HOME/.aws/`. You can choose your AWS profile and files location by using
 `aws.aws_profile` and `aws.aws_dir`, however environment variables will always
 have precedence as defined by the [AWS documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html).
+To use profile `vagrantDev` from your AWS files:
+```ruby
+  # this first line can actually be omitted
+  aws.aws_dir = ENV['HOME'] + "/.aws/"
+  aws.aws_profile = "vagrantDev"
+```
+
 
 ## Box Format
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ are being launched with a security group that allows SSH access.
 Note: if you don't configure `aws.access_key_id` or `aws_secret_access_key`
 it will attempt to read credentials from environment variables first and then
 from `$HOME/.aws/`. You can choose your AWS profile and files location by using
-`aws.aws_profile` and `aws.aws_dir`.
+`aws.aws_profile` and `aws.aws_dir`, however environment variables will always
+have precedence as defined by the [AWS documentation](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html).
 
 ## Box Format
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,8 @@ Dir.chdir(File.expand_path("../", __FILE__))
 Bundler::GemHelper.install_tasks
 
 # Install the `spec` task so that we can run tests.
-RSpec::Core::RakeTask.new
-
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.rspec_opts = "--order defined"
+end
 # Default task is to run the unit tests
-task :default => "spec"
+task :default => :spec

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -330,6 +330,9 @@ module VagrantPlugins
           @aws_dir = nil
         end
 
+        # session token must be set to nil, empty string isn't enough!
+        @session_token = nil if @session_token == UNSET_VALUE
+
         # AMI must be nil, since we can't default that
         @ami = nil if @ami == UNSET_VALUE
 

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -509,9 +509,9 @@ module VagrantPlugins
         aws_config = location + 'config'
         aws_creds = location + 'credentials'
 
-        # profile line to match
+        # profile line to match in .aws/config
         pat = ''
-        if profile == '' or profile == 'default'
+        if profile == 'default'
           pat = '\[default\]'
         else
           pat = '\[profile ' + profile + '\]'
@@ -525,13 +525,8 @@ module VagrantPlugins
           aws_region = ''
         end
 
-        # profile line to match
-        pat = ''
-        if profile == '' or profile == 'default'
-          pat = '\[default\]'
-        else
-          pat = '\[' + profile + '\]'
-        end
+        # profile line to match in .aws/credentials
+        pat = '\[' + profile + '\]'
         # read credentials file for selected profile
         begin
           aws_token = ''

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -316,13 +316,9 @@ module VagrantPlugins
       end
 
       def finalize!
-        # Try to get access keys from standard AWS environment variables; they
-        # will default to nil if the environment variables are not present.
-        #@access_key_id     = ENV['AWS_ACCESS_KEY'] if @access_key_id     == UNSET_VALUE
-        #@secret_access_key = ENV['AWS_SECRET_KEY'] if @secret_access_key == UNSET_VALUE
-        #@session_token     = ENV['AWS_SESSION_TOKEN'] if @session_token == UNSET_VALUE
-        puts "----------------------------------------"
-        #
+        # If access_key_id or secret_access_key were not specified in Vagrantfile
+        # then try to read from environment variables first, and if it fails from
+        # the AWS folder.
         if @access_key_id == UNSET_VALUE or @secret_access_key == UNSET_VALUE
           @aws_profile = 'default' if @aws_profile == UNSET_VALUE
           @aws_dir = ENV['HOME'] + '/.aws/' if @aws_dir == UNSET_VALUE
@@ -332,12 +328,6 @@ module VagrantPlugins
           @aws_dir = nil
           @session_token = nil
         end
-        puts "'" + @region.to_s + "'"
-        puts "'" + @access_key_id.to_s + "'"
-        puts "'" + @secret_access_key.to_s + "'"
-        puts "'" + @session_token.to_s + "'"
-        #
-        puts "----------------------------------------"
 
         # AMI must be nil, since we can't default that
         @ami = nil if @ami == UNSET_VALUE
@@ -500,14 +490,9 @@ module VagrantPlugins
         # read from environment variables
         aws_region, aws_id, aws_secret, aws_token = read_aws_environment()
         # if nothing there, then read from files
-        if not is_aws_configured(aws_id, aws_secret, aws_region)
+        if aws_id.to_s == '' or aws_secret.to_s == '' or aws_region.to_s == ''
           aws_region, aws_id, aws_secret, aws_token = read_aws_files(profile, location)
         end
-        #if not is_aws_configured(aws_id, aws_secret, aws_region)
-        #  msg = "One or more of the needed AWS credentials are missing."
-        #  msg += " Does profile '" + profile + "' exists at " + location + " ?"
-        #  raise Exception.new(msg)
-        #end
         aws_region = nil if aws_region == ''
         aws_id     = nil if aws_id == ''
         aws_secret = nil if aws_secret == ''
@@ -573,10 +558,6 @@ module VagrantPlugins
         return aws_region, aws_id, aws_secret, aws_token
       end
 
-      def is_aws_configured(aws_id, aws_secret, aws_region)
-        return true if aws_id.to_s != '' and aws_secret.to_s != '' and aws_region.to_s != ''
-        return false
-      end
     end
 
 

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -321,12 +321,12 @@ module VagrantPlugins
         # the AWS folder.
         if @access_key_id == UNSET_VALUE or @secret_access_key == UNSET_VALUE
           @aws_profile = 'default' if @aws_profile == UNSET_VALUE
-          @aws_dir = ENV['HOME'] + '/.aws/' if @aws_dir == UNSET_VALUE
+          @aws_dir = ENV['HOME'].to_s + '/.aws/' if @aws_dir == UNSET_VALUE
           @region, @access_key_id, @secret_access_key, @session_token = Credentials.new.get_aws_info(@aws_profile, @aws_dir)
+          @region = UNSET_VALUE if @region.nil?
         else
           @aws_profile = nil
           @aws_dir = nil
-          @session_token = nil
         end
 
         # AMI must be nil, since we can't default that
@@ -490,7 +490,8 @@ module VagrantPlugins
         # read from environment variables
         aws_region, aws_id, aws_secret, aws_token = read_aws_environment()
         # if nothing there, then read from files
-        if aws_id.to_s == '' or aws_secret.to_s == '' or aws_region.to_s == ''
+        # it doesn't check aws_region since Config#finalize sets one by default
+        if aws_id.to_s == '' or aws_secret.to_s == ''
           aws_region, aws_id, aws_secret, aws_token = read_aws_files(profile, location)
         end
         aws_region = nil if aws_region == ''

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -475,17 +475,22 @@ module VagrantPlugins
 
 
     class Credentials < Vagrant.plugin("2", :config)
-      # This module reads AWS config and credentials from environment variables
-      # or, if these are not defined, by reading the corresponding files. So the
-      # behaviour is all-or-nothing (ie: no mixing between vars and files).
-      # It allows choosing a profile (by default it's [default]) and an "info"
-      # directory (by default $HOME/.aws).
-      # Supported information: region, aws_access_key_id, aws_secret_access_key,
-      # and aws_session_token.
-      #
-      # AWS credentials specification:
-      # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files
+      # This module reads AWS config and credentials. 
+      # Behaviour aims to mimic what is described in AWS documentation:
+      # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
       # http://docs.aws.amazon.com/cli/latest/topic/config-vars.html
+      # Which is the following (stopping at the first successful case):
+      # 1) read config and credentials from environment variables
+      # 2) read config and credentials from files at location defined by environment variables
+      # 3) read config and credentials from files at default location 
+      #
+      # The mandatory fields for a successful "get credentials" are the id and the secret keys.
+      # Region is not required since Config#finalize falls back to sensible defaults.
+      # The behaviour is all-or-nothing (ie: no mixing between vars and files).
+      #
+      # It also allows choosing a profile (by default it's [default]) and an "info"
+      # directory (by default $HOME/.aws), which can be specified in the Vagrantfile.
+      # Supported information: region, aws_access_key_id, aws_secret_access_key, and aws_session_token.
 
       def get_aws_info(profile, location)
         # read credentials from environment variables

--- a/lib/vagrant-aws/version.rb
+++ b/lib/vagrant-aws/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module AWS
-    VERSION = '0.7.0'
+    VERSION = '0.7.1'
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -76,6 +76,9 @@ en:
         A secret access key is required via "secret_access_key"
       subnet_id_required_with_public_ip: |-
         If you assign a public IP address to an instance in a VPC, a subnet must be specifed via "subnet_id"
+      aws_info_required: |-
+        One or more of the needed AWS credentials are missing. No environment variables
+        are set nor profile '%{profile}' exists at '%{location}'
 
     errors:
       fog_error: |-

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -62,6 +62,10 @@ describe VagrantPlugins::AWS::Config do
       :source_dest_check].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
+        # but these should always come together, so you need to set them all or nothing
+        instance.send("access_key_id=".to_sym, "foo")
+        instance.send("secret_access_key=".to_sym, "foo")
+        instance.send("session_token=".to_sym, "foo")
         instance.send("#{attribute}=".to_sym, "foo")
         instance.finalize!
         instance.send(attribute).should == "foo"
@@ -89,8 +93,8 @@ describe VagrantPlugins::AWS::Config do
 
     context "with EC2 credential environment variables" do
       before :each do
-        ENV.stub(:[]).with("AWS_ACCESS_KEY").and_return("access_key")
-        ENV.stub(:[]).with("AWS_SECRET_KEY").and_return("secret_key")
+        ENV.stub(:[]).with("AWS_ACCESS_KEY_ID").and_return("access_key")
+        ENV.stub(:[]).with("AWS_SECRET_ACCESS_KEY").and_return("secret_key")
         ENV.stub(:[]).with("AWS_SESSION_TOKEN").and_return("session_token")
       end
 
@@ -187,6 +191,7 @@ describe VagrantPlugins::AWS::Config do
 
         # Set some top-level values
         instance.access_key_id = "parent"
+        instance.secret_access_key = "parent"
         instance.ami = "parent"
 
         # Finalize and get the region
@@ -195,6 +200,7 @@ describe VagrantPlugins::AWS::Config do
       end
 
       its("access_key_id") { should == "parent" }
+      its("secret_access_key") { should == "parent" }
       its("ami")           { should == "child" }
     end
 

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -188,7 +188,7 @@ aws_session_token= TOKuser3
       its("region")               { should == "env_region" }
     end
 
-    context "without EC2 credential environment variables but with AWS_SHARED_CREDENTIALS_FILE set" do
+    context "without EC2 credential environment variables but with AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE set" do
       subject do
         allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
         allow(File).to receive(:read).with(filename_keys).and_return(data_keys)
@@ -206,7 +206,7 @@ aws_session_token= TOKuser3
       its("region")                { should == "sh-region" }
     end
 
-    context "without EC2 credential environment variables and fallback to default profile" do
+    context "without any credential environment variables and fallback to default profile at default location" do
       subject do
         allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
         allow(File).to receive(:read).with(filename_keys).and_return(data_keys)
@@ -219,7 +219,7 @@ aws_session_token= TOKuser3
       its("session_token")         { should be_nil }
     end
 
-    context "without EC2 credential environment variables and chosing a profile" do
+    context "without any credential environment variables and chosing a profile" do
       subject do
         allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
         allow(File).to receive(:read).with(filename_keys).and_return(data_keys)

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -190,6 +190,7 @@ aws_session_token= TOKuser3
 
     context "without EC2 credential environment variables but with AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE set" do
       subject do
+        allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
         allow(File).to receive(:read).with(filename_keys).and_return(data_keys)
         ENV.stub(:[]).with("AWS_CONFIG_FILE").and_return(sh_filename_cfg)
@@ -208,6 +209,7 @@ aws_session_token= TOKuser3
 
     context "without any credential environment variables and fallback to default profile at default location" do
       subject do
+        allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
         allow(File).to receive(:read).with(filename_keys).and_return(data_keys)
         instance.tap do |o|
@@ -221,6 +223,7 @@ aws_session_token= TOKuser3
 
     context "without any credential environment variables and chosing a profile" do
       subject do
+        allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
         allow(File).to receive(:read).with(filename_keys).and_return(data_keys)
         instance.aws_profile = "user3"

--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "fog", "~> 1.22"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 2.12"
+  # rspec 3.4 to mock File
+  s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "rspec-its"
 
   # The following block of code determines the files that should be included

--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "vagrant-aws"
 
   s.add_runtime_dependency "fog", "~> 1.22"
+  s.add_runtime_dependency "iniparse", "~> 1.4", ">= 1.4.2"
 
   s.add_development_dependency "rake"
   # rspec 3.4 to mock File


### PR DESCRIPTION
When either access_key_id or secret_access_key are not set it will attempt to read from environment variables, if those are empty then it will attempt to read from config and credentials.
It allows choosing a profile (by default it's "default") and an "info" directory (by default $HOME/.aws).
Supported information: region, aws_access_key_id, aws_secret_access_key and aws_session_token.

Closes issue #151
