### PR TITLE
Fix duplicated key warning

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -97,7 +97,6 @@ module VagrantPlugins
             :ebs_optimized             => ebs_optimized,
             :associate_public_ip       => associate_public_ip,
             :kernel_id                 => kernel_id,
-            :associate_public_ip       => associate_public_ip,
             :tenancy                   => tenancy
           }
 


### PR DESCRIPTION
Suppress the following warning.

```
$ vagrant up
/home/akihyro/.vagrant.d/gems/gems/vagrant-aws-0.7.0/lib/vagrant-aws/action/run_instance.rb:98: warning: duplicated key at line 100 ignored: :associate_public_ip
```
