### PR TITLE
Execute provisioner cleanup before terminating the instance

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -46,7 +46,7 @@ module VagrantPlugins
             if env[:result]
               b2.use ConfigValidate
               b2.use Call, IsCreated do |env2, b3|
-                unless env2[:result]
+                if !env2[:result]
                   b3.use MessageNotCreated
                   next
                 end

--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -46,14 +46,15 @@ module VagrantPlugins
             if env[:result]
               b2.use ConfigValidate
               b2.use Call, IsCreated do |env2, b3|
-                if !env2[:result]
+                unless env2[:result]
                   b3.use MessageNotCreated
                   next
                 end
+
                 b3.use ConnectAWS
                 b3.use ElbDeregisterInstance
+                b3.use ProvisionerCleanup, :before if defined?(ProvisionerCleanup)
                 b3.use TerminateInstance
-                b3.use ProvisionerCleanup if defined?(ProvisionerCleanup)
               end
             else
               b2.use MessageWillNotDestroy


### PR DESCRIPTION
**Problem**: On a setup with chef-client as a provisioner, I had trouble `vagrant destroy`ing my machines, since chef-client tries to execute `knife` over ssh, [see this](https://github.com/mitchellh/vagrant/blob/master/plugins/provisioners/chef/provisioner/chef_client.rb#l153), but the instance is already terminated. So the result was an SSHNotReady error and an exit status of 1.

**Solution**: ProvisionerCleanup is executed just before the instance is terminated, which, as I understood, is the intended behavior for vagrant, currently