### PR TITLE
Fix vagrant-aws package error caused by pre-flight package validation move

### DIFF
--- a/lib/vagrant-aws/action/package_instance.rb
+++ b/lib/vagrant-aws/action/package_instance.rb
@@ -25,10 +25,9 @@ module VagrantPlugins
         include Vagrant::Util::Retryable
 
         def initialize(app, env)
-          @app    = app
+          super
           @logger = Log4r::Logger.new("vagrant_aws::action::package_instance")
           env["package.include"] ||= []
-          env["package.output"] ||= "package.box"
         end
 
         alias_method :general_call, :call


### PR DESCRIPTION
This plugin uses its own initialize for package that does not contain the
definition of @fullpath.  @fullpath was introduced into intialize with vagrant
1.8.4.  This results in an undefined method error.  This change fixes it.

Caused by https://github.com/mitchellh/vagrant/pull/7353/commits/efdb148f61879b838d3725644d78a1221d6ef5f4
Fixes https://github.com/mitchellh/vagrant-aws/issues/471