### PR TITLE
Allow override region from Vagrantfile

### DIFF
--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -323,8 +323,8 @@ module VagrantPlugins
         if @access_key_id == UNSET_VALUE or @secret_access_key == UNSET_VALUE
           @aws_profile = 'default' if @aws_profile == UNSET_VALUE
           @aws_dir = ENV['HOME'].to_s + '/.aws/' if @aws_dir == UNSET_VALUE
-          @region, @access_key_id, @secret_access_key, @session_token = Credentials.new.get_aws_info(@aws_profile, @aws_dir)
-          @region = UNSET_VALUE if @region.nil?
+          @aws_region, @access_key_id, @secret_access_key, @session_token = Credentials.new.get_aws_info(@aws_profile, @aws_dir)
+          @region = @aws_region if @region == UNSET_VALUE and !@aws_region.nil?
         else
           @aws_profile = nil
           @aws_dir = nil

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -219,6 +219,23 @@ aws_session_token= TOKuser3
       its("access_key_id")         { should == "AKIdefault" }
       its("secret_access_key")     { should == "PASSdefault" }
       its("session_token")         { should be_nil }
+      its("region")                { should == "eu-west-1" }
+    end
+
+    context "with default profile and overriding region" do
+      subject do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:read).with(filename_cfg).and_return(data_cfg)
+        allow(File).to receive(:read).with(filename_keys).and_return(data_keys)
+        instance.region = "eu-central-1"
+        instance.tap do |o|
+          o.finalize!
+        end
+      end
+      its("access_key_id")         { should == "AKIdefault" }
+      its("secret_access_key")     { should == "PASSdefault" }
+      its("session_token")         { should be_nil }
+      its("region")                { should == "eu-central-1" }
     end
 
     context "without any credential environment variables and chosing a profile" do


### PR DESCRIPTION
It should be possible to override region from Vagrantfile when using AWS profile files.

Probably fix #473 
