### PR TITLE
Fix entry about "security_groups" in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ This provider exposes quite a few provider-specific configuration options:
   to an existing Elastic IP address, assign the address to the instance.
 * `region` - The region to start the instance in, such as "us-east-1"
 * `secret_access_key` - The secret access key for accessing AWS
-* `security_groups` - An array of security groups for the instance. If this
-  instance will be launched in VPC, this must be a list of security group
-  Name. For a nondefault VPC, you must use security group IDs instead (http://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html).
+* `security_groups` - An array of one or more security groups for the instance. If the 
+  instance will be launched in a default VPC, you must specify the security groups by Group Name.
+  If the instance will be launched in a nondefault VPC, you must specify the security groups by Group ID 
+  (see Options --security grpus at http://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html).
 * `iam_instance_profile_arn` - The Amazon resource name (ARN) of the IAM Instance
     Profile to associate with the instance
 * `iam_instance_profile_name` - The name of the IAM Instance Profile to associate


### PR DESCRIPTION
The entry on security groups, as written, does not fully make sense because it contrasts "VPC" and "nondefault VPC." But a "nodefault VPC" is still a "VPC"; in other words, the two categories actually overlap. The text should refer to a "default VPC" versus a "nondefault VPC"—categories that are mutually exclusive and exhaustive. 

While this may seem trivial, it confused me when I was trying to figure out whether to use Group Name or Group ID in my Vagrantfile. I have made some other minor changes that I think make the language even clearer.