### PR TITLE
rsync on provision

### DIFF
--- a/lib/vagrant-aws/action.rb
+++ b/lib/vagrant-aws/action.rb
@@ -74,6 +74,7 @@ module VagrantPlugins
             end
 
             b2.use Provision
+            b2.use SyncedFolders
           end
         end
       end


### PR DESCRIPTION
According to https://github.com/janschumann/vagrant-aws#synced-folders, folders will be synced on `up`, `reload` and `provision` actions. But for `provision` the `SyncedFolders` task was missing.

When placing `b2.use SyncedFolders` before `b2.use Provision` the folder sync is executed AFTER provisioning. Is that intended? Nevertheless I placed it after provisioning and now it works correctly.