### PR TITLE
locking "fog-core" to keep ruby < 2.3 support

### DIFF
--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -16,6 +16,9 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "vagrant-aws"
 
   s.add_runtime_dependency "fog", "~> 1.22"
+  # 1.44 requires xmlrpc which only supports >= ruby 2.3
+  # https://github.com/fog/fog-core/issues/206
+  s.add_runtime_dependency 'fog-core', '1.43.0'
   s.add_runtime_dependency "iniparse", "~> 1.4", ">= 1.4.2"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Related issues:
* https://github.com/fog/fog-core/issues/206
* https://github.com/mitchellh/vagrant/issues/8538

Fixing : https://github.com/mitchellh/vagrant-aws/issues/510