### PR TITLE
Add support to attach existing eni at index 0 on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,14 @@ This provider exposes quite a few provider-specific configuration options:
 * `secret_access_key` - The secret access key for accessing AWS
 * `security_groups` - An array of security groups for the instance. If this
   instance will be launched in VPC, this must be a list of security group
-  Name. For a nondefault VPC, you must use security group IDs instead (http://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html).
+  Name. For a nondefault VPC, you must use security group IDs instead (http://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html).  This can not be used when setting `network_interface`.
 * `iam_instance_profile_arn` - The Amazon resource name (ARN) of the IAM Instance
     Profile to associate with the instance
 * `iam_instance_profile_name` - The name of the IAM Instance Profile to associate
   with the instance
-* `subnet_id` - The subnet to boot the instance into, for VPC.
+* `subnet_id` - The subnet to boot the instance into, for VPC.  This can not be used when setting `network_interface`.
 * `associate_public_ip` - If true, will associate a public IP address to an instance in a VPC.
+* `network_interface` - The id of an existing elastic network interface (eni) to be used as the primary network interface.  If this is specified, `security_groups` and `subnet_id` must be left blank.
 * `ssh_host_attribute` - If `:public_ip_address`, `:dns_name`, or
   `:private_ip_address`, will use the public IP address, DNS name, or private
   IP address, respectively, to SSH to the instance. By default Vagrant uses the

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
           env[:ui].info(" -- Availability Zone: #{availability_zone}") if availability_zone
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(" -- Subnet ID: #{subnet_id}") if subnet_id
-          env[:ui].info(" -- Network Interface: ${network_interface}") if network_interface
+          env[:ui].info(" -- Network Interface: #{network_interface}") if network_interface
           env[:ui].info(" -- IAM Instance Profile ARN: #{iam_instance_profile_arn}") if iam_instance_profile_arn
           env[:ui].info(" -- IAM Instance Profile Name: #{iam_instance_profile_name}") if iam_instance_profile_name
           env[:ui].info(" -- Private IP: #{private_ip_address}") if private_ip_address
@@ -102,7 +102,7 @@ module VagrantPlugins
             :tenancy                   => tenancy
           }
 
-          if !network_interface.empty?
+          if network_interface
             options[:network_interfaces] = [
               {
                 :NetworkInterfaceId => network_interface,

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -33,6 +33,7 @@ module VagrantPlugins
           private_ip_address    = region_config.private_ip_address
           security_groups       = region_config.security_groups
           subnet_id             = region_config.subnet_id
+          network_interface     = region_config.network_interface
           tags                  = region_config.tags
           user_data             = region_config.user_data
           block_device_mapping  = region_config.block_device_mapping
@@ -65,6 +66,7 @@ module VagrantPlugins
           env[:ui].info(" -- Availability Zone: #{availability_zone}") if availability_zone
           env[:ui].info(" -- Keypair: #{keypair}") if keypair
           env[:ui].info(" -- Subnet ID: #{subnet_id}") if subnet_id
+          env[:ui].info(" -- Network Interface: ${network_interface}") if network_interface
           env[:ui].info(" -- IAM Instance Profile ARN: #{iam_instance_profile_arn}") if iam_instance_profile_arn
           env[:ui].info(" -- IAM Instance Profile Name: #{iam_instance_profile_name}") if iam_instance_profile_name
           env[:ui].info(" -- Private IP: #{private_ip_address}") if private_ip_address
@@ -99,6 +101,15 @@ module VagrantPlugins
             :kernel_id                 => kernel_id,
             :tenancy                   => tenancy
           }
+
+          if !network_interface.empty?
+            options[:network_interfaces] = [
+              {
+                :NetworkInterfaceId => network_interface,
+                :DeviceIndex         => 0
+              }
+            ]
+          end
 
           if !security_groups.empty?
             security_group_key = options[:subnet_id].nil? ? :groups : :security_group_ids

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -104,6 +104,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :subnet_id
 
+      # The network interface to launch the machine with.  Cannot be specified with subnet_id or security_groups
+      #
+      # @return [String]
+      attr_accessor :network_interface
+
       # The tags for the machine.
       #
       # @return [Hash<String, String>]

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -42,6 +42,7 @@ describe VagrantPlugins::AWS::Config do
     its("session_token") { should be_nil }
     its("security_groups")   { should == [] }
     its("subnet_id")         { should be_nil }
+    its("network_interface") { should be_nil }
     its("iam_instance_profile_arn") { should be_nil }
     its("iam_instance_profile_name") { should be_nil }
     its("tags")              { should == {} }
@@ -68,7 +69,7 @@ describe VagrantPlugins::AWS::Config do
     [:access_key_id, :ami, :availability_zone, :instance_ready_timeout,
       :instance_package_timeout, :instance_type, :keypair_name, :ssh_host_attribute,
       :ebs_optimized, :region, :secret_access_key, :session_token, :monitoring,
-      :associate_public_ip, :subnet_id, :tags, :package_tags, :elastic_ip,
+      :associate_public_ip, :subnet_id, :network_interface, :tags, :package_tags, :elastic_ip,
       :terminate_on_shutdown, :iam_instance_profile_arn, :iam_instance_profile_name,
       :use_iam_profile, :user_data, :block_device_mapping,
       :source_dest_check].each do |attribute|


### PR DESCRIPTION
This is particularly useful if you have a compiler or application that is locked to a mac address.  As long as you continue to use the same ENI, you have the same mac address.