### PR TITLE
Spot Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ EC2 and VPC.
 * Define region-specific configurations so Vagrant can manage machines
   in multiple regions.
 * Package running instances into new vagrant-aws friendly boxes
+* Spot Instance Support
 
 ## Usage
 
@@ -169,6 +170,10 @@ This provider exposes quite a few provider-specific configuration options:
 * `terminate_on_shutdown` - Indicates whether an instance stops or terminates
   when you initiate shutdown from the instance.
 * `endpoint` - The endpoint URL for connecting to AWS (or an AWS-like service). Only required for non AWS clouds, such as [eucalyptus](https://github.com/eucalyptus/eucalyptus/wiki).
+
+* `spot_instance` - Boolean value; indicates whether the config is for a spot instance, or on-demand. For more information about spot instances, see the [AWS Documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-spot-instances-work.html)
+* `spot_max_price` - Decimal value; state the maximum bid for your spot instance. Ignored if `spot_instance` is not true.
+* `spot_valid_until` - Timestamp; when this spot instance request should expire, destroying any related instances. Ignored if `spot_instance` is not true.
 
 These can be set like typical provider-specific configuration:
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ This provider exposes quite a few provider-specific configuration options:
 * `endpoint` - The endpoint URL for connecting to AWS (or an AWS-like service). Only required for non AWS clouds, such as [eucalyptus](https://github.com/eucalyptus/eucalyptus/wiki).
 
 * `spot_instance` - Boolean value; indicates whether the config is for a spot instance, or on-demand. For more information about spot instances, see the [AWS Documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-spot-instances-work.html)
-* `spot_max_price` - Decimal value; state the maximum bid for your spot instance. Ignored if `spot_instance` is not true.
+* `spot_max_price` - Decimal value; state the maximum bid for your spot instance. If nil, it will compute average price in `region` for selected `instance_type`.
+* `spot_price_product_description` - The product description for the spot price history used to compute average price. Defaults to 'Linux/UNIX'. 
 * `spot_valid_until` - Timestamp; when this spot instance request should expire, destroying any related instances. Ignored if `spot_instance` is not true.
 
 These can be set like typical provider-specific configuration:

--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -107,7 +107,11 @@ module VagrantPlugins
           end
 
           begin
-            server = env[:aws_compute].servers.create(options)
+            server = if region_config.spot_instance
+                       server_from_spot_request(env, region_config, options)
+                     else
+                       env[:aws_compute].servers.create(options)
+                     end
           rescue Fog::Compute::AWS::NotFound => e
             # Invalid subnet doesn't have its own error so we catch and
             # check the error message here.
@@ -210,6 +214,62 @@ module VagrantPlugins
           terminate(env) if env[:interrupted]
 
           @app.call(env)
+        end
+
+        # returns a fog server or nil
+        def server_from_spot_request(env, config, options)
+          options.merge!({
+            :price => config.spot_max_price,
+            :valid_until => config.spot_valid_until
+          })
+
+          env[:ui].info(I18n.t("vagrant_aws.launching_spot_instance"))
+          env[:ui].info(" -- Price: #{config.spot_max_price}")
+          env[:ui].info(" -- Valid until: #{config.spot_valid_until}") if config.spot_valid_until
+
+          # create the spot instance
+          spot_req = env[:aws_compute].spot_requests.create(options)
+
+          @logger.info("Spot request ID: #{spot_req.id}")
+
+          # initialize state
+          status_code = ""
+          while true
+            sleep 5
+
+            spot_req.reload()
+
+            # display something whenever the status code changes
+            if status_code != spot_req.state
+              env[:ui].info(spot_req.fault)
+              status_code = spot_req.state
+            end
+            spot_state = spot_req.state.to_sym
+            case spot_state
+            when :not_created, :open
+              @logger.debug("Spot request #{spot_state} #{status_code}, waiting")
+            when :active
+              break; # :)
+            when :closed, :cancelled, :failed
+              msg = "Spot request #{spot_state} #{status_code}, aborting"
+              @logger.error(msg)
+              raise Errors::FogError, :message => msg
+            else
+              @logger.debug("Unknown spot state #{spot_state} #{status_code}, waiting")
+            end
+          end
+          # cancel the spot request but let the server go thru
+          spot_req.destroy()
+
+          server = env[:aws_compute].servers.get(spot_req.instance_id)
+
+          # Spot Instances don't support tagging arguments on creation
+          # Retrospectively tag the server to handle this
+          if !config.tags.empty?
+            env[:aws_compute].create_tags(server.identity, config.tags)
+          end
+
+          server
         end
 
         def recover(env)

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -211,6 +211,11 @@ module VagrantPlugins
       # @return [Time]
       attr_accessor :spot_valid_until
 
+      # The product description for the spot price history
+      #
+      # @return [String]
+      attr_accessor :spot_price_product_description
+
       def initialize(region_specific=false)
         @access_key_id             = UNSET_VALUE
         @ami                       = UNSET_VALUE
@@ -430,11 +435,14 @@ module VagrantPlugins
         # By default don't use spot requests
         @spot_instance = false if @spot_instance == UNSET_VALUE
 
-        # Required, no default
+        # default to nil
         @spot_max_price = nil if @spot_max_price == UNSET_VALUE
 
         # Default: Request is effective indefinitely.
         @spot_valid_until = nil if @spot_valid_until == UNSET_VALUE
+
+        # default to nil
+        @spot_price_product_description = nil if @spot_price_product_description == UNSET_VALUE
 
         # Compile our region specific configurations only within
         # NON-REGION-SPECIFIC configurations.
@@ -487,7 +495,6 @@ module VagrantPlugins
           end
 
           errors << I18n.t("vagrant_aws.config.ami_required", :region => @region)  if config.ami.nil?
-          errors << I18n.t("vagrant_aws.config.spot_price_required") if config.spot_instance && config.spot_max_price.nil?
         end
 
         { "AWS Provider" => errors }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -70,8 +70,6 @@ en:
         An access key ID must be specified via "access_key_id"
       ami_required: |-
         An AMI must be configured via "ami" (region: #{region})
-      spot_price_required: |-
-         Spot request is missing "spot_max_price"
       private_key_missing: |-
         The specified private key for AWS could not be found
       region_required: |-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -18,6 +18,8 @@ en:
 
     launching_instance: |-
       Launching an instance with the following settings...
+    launching_spot_instance: |-
+       Launching a spot request instance with the following settings...
     launch_no_keypair: |-
       Warning! You didn't specify a keypair to launch your instance with.
       This can sometimes result in not being able to access your instance.
@@ -68,6 +70,8 @@ en:
         An access key ID must be specified via "access_key_id"
       ami_required: |-
         An AMI must be configured via "ami" (region: #{region})
+      spot_price_required: |-
+         Spot request is missing "spot_max_price"
       private_key_missing: |-
         The specified private key for AWS could not be found
       region_required: |-
@@ -104,7 +108,7 @@ en:
         Error: %{err}
       instance_package_timeout: |-
         The AMI failed to become "ready" in AWS. The timeout currently
-        set waiting for the instance to become ready is %{timeout} seconds. For 
+        set waiting for the instance to become ready is %{timeout} seconds. For
         larger instances AMI burning may take long periods of time. Please
         ensure the timeout is set high enough, it can be changed by adjusting
         the `instance_package_timeout` configuration on the AWS provider.

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -58,6 +58,9 @@ describe VagrantPlugins::AWS::Config do
     its("associate_public_ip")     { should == false }
     its("unregister_elb_from_az") { should == true }
     its("tenancy")     { should == "default" }
+    its("spot_instance")     { should == false }
+    its("spot_max_price")    { should be_nil }
+    its("spot_valid_until")  { should be_nil }
   end
 
   describe "overriding defaults" do

--- a/spec/vagrant-aws/config_spec.rb
+++ b/spec/vagrant-aws/config_spec.rb
@@ -60,6 +60,7 @@ describe VagrantPlugins::AWS::Config do
     its("tenancy")     { should == "default" }
     its("spot_instance")     { should == false }
     its("spot_max_price")    { should be_nil }
+    its("spot_price_product_description")  { should be_nil }
     its("spot_valid_until")  { should be_nil }
   end
 


### PR DESCRIPTION
Follow up of #430 

With additional enhancements:

- spot instance is started with same options as on-demand instance, so it's possible to setup device mapping, IAM instance profile and so on
- user interruption is correctly handled and after spot fulfilment instance is terminated
- if `spot_max_price` is not defined average price is computed

Fix #32, #338, https://github.com/KariusDx/vagrant-aws/pull/2