### PR TITLE
Block on instance termination

### DIFF
--- a/lib/vagrant-aws/action/terminate_instance.rb
+++ b/lib/vagrant-aws/action/terminate_instance.rb
@@ -28,6 +28,7 @@ module VagrantPlugins
           # Destroy the server and remove the tracking ID
           env[:ui].info(I18n.t("vagrant_aws.terminating"))
           server.destroy
+          server.wait_for { server.state == 'terminated' }
           env[:machine].id = nil
 
           @app.call(env)


### PR DESCRIPTION
With other Vagrant plugins that I've used, the instance/VM is fully destroyed when the `vagrant destroy` command returns. It's useful to be able to have that guarantee for the end user. 