### PR TITLE
Swap to fog-aws

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :development do
 end
 
 group :plugins do
-  gem "vagrant-aws" , path: "."
+  gemspec
 end

--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog-aws"
 require "log4r"
 
 module VagrantPlugins

--- a/lib/vagrant-aws/config.rb
+++ b/lib/vagrant-aws/config.rb
@@ -525,25 +525,17 @@ module VagrantPlugins
       private
 
       def read_aws_files(profile, aws_config, aws_creds)
-        # determine section in config ini file
-        if profile == 'default'
-          ini_profile = profile
-        else
-          ini_profile = 'profile ' + profile
-        end
         # get info from config ini file for selected profile
         data = File.read(aws_config)
         doc_cfg = IniParse.parse(data)
-        aws_region = doc_cfg[ini_profile]['region']
+        aws_region = doc_cfg[profile]['region']
 
-        # determine section in credentials ini file
-        ini_profile = profile
         # get info from credentials ini file for selected profile
         data = File.read(aws_creds)
         doc_cfg = IniParse.parse(data)
-        aws_id = doc_cfg[ini_profile]['aws_access_key_id']
-        aws_secret = doc_cfg[ini_profile]['aws_secret_access_key']
-        aws_token = doc_cfg[ini_profile]['aws_session_token']
+        aws_id = doc_cfg[profile]['aws_access_key_id']
+        aws_secret = doc_cfg[profile]['aws_secret_access_key']
+        aws_token = doc_cfg[profile]['aws_session_token']
 
         return aws_region, aws_id, aws_secret, aws_token
       end

--- a/lib/vagrant-aws/version.rb
+++ b/lib/vagrant-aws/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module AWS
-    VERSION = '0.7.2'
+    VERSION = '0.8.0'
   end
 end

--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -1,4 +1,6 @@
-$:.unshift File.expand_path("../lib", __FILE__)
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "vagrant-aws/version"
 
 Gem::Specification.new do |s|
@@ -15,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-aws"
 
-  s.add_runtime_dependency "fog", "~> 1.22"
+  s.add_runtime_dependency "fog-aws", "~> 3.0"
   s.add_runtime_dependency "iniparse", "~> 1.4", ">= 1.4.2"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
We don't need all of Fog, only the AWS portion of it.

This should resolve #539 

Additionally, removed weird logic for finding ~/.aws/config profile