### PR TITLE
Add note about unsupported repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,61 @@
+---
+name: Vagrant-AWS Bug Report
+about: For when vagrant-aws is not working as expected or you have encountered a bug
+
+---
+
+**Please note that this plugin is no longer supported by HashiCorp and does not
+have an official maintainer to handle your issue or bug report.**
+
+### Vagrant version
+
+Run `vagrant -v` to show the version. If you are not running the latest version
+of Vagrant, please upgrade before submitting an issue.
+
+### Vagrant-AWS plugin version
+
+### Host operating system
+
+This is the operating system that you run locally.
+
+### Guest operating system
+
+This is the operating system you run in the virtual machine.
+
+### Vagrantfile
+
+```ruby
+# Copy-paste your Vagrantfile here (but don't include sensitive information such as passwords, authentication tokens, or email addresses)
+```
+
+Please note, if you are using Homestead or a different Vagrantfile format, we
+may be unable to assist with your issue. Try to reproduce the issue using a
+vanilla Vagrantfile first.
+
+### Debug output
+
+Provide a link to a GitHub Gist containing the complete debug output:
+https://www.vagrantup.com/docs/other/debugging.html. The debug output should
+be very long. Do NOT paste the debug output in the issue, just paste the
+link to the Gist.
+
+### Expected behavior
+
+What should have happened?
+
+### Actual behavior
+
+What actually happened?
+
+### Steps to reproduce
+
+1.
+2.
+3.
+
+### References
+
+Are there any other GitHub issues (open or closed) that should be linked here?
+For example:
+- GH-1234
+- ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Vagrant AWS Provider
+
+# Official Support
+
+**This plugin is no longer officially supported by HashiCorp, and is no longer maintained.
+It should only be used at your own risk, as the plugin may or may not work and is subject
+to breaking changes in future releases of Vagrant.**
+
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/mitchellh/vagrant-aws?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 <span class="badges">


### PR DESCRIPTION
Hey there @mitchellh - We were hoping that we could get a note on this repo to let people know that this plugin is no longer supported. I think maybe @rtyler is a maintainer too? Either way, it doesn't look like there's been much traction on any of the issues or pull requests, so it would be nice to let folks know that this plugin isn't really being supported. There has been some confusion around if this is something official (since it's on @mitchellh 's page) and supported, since there are other HashiCorp tools where this is true.

The other alternative is the archive this repo so it's clear that support has stopped. That would prevent others from contributing fixes or opening issues, but it doesn't look like those are being triaged anyway. At the very least, this pull request adds a note to the README and new issue templates to let folks know what's going on.

Hope that makes some sense! Let me know if there's anything I can do, thanks!