### PR TITLE
Specify all dependencies of this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a [Vagrant](http://www.vagrantup.com) 1.2+ plugin that adds an [AWS](htt
 provider to Vagrant, allowing Vagrant to control and provision machines in
 EC2 and VPC.
 
-**NOTE:** This plugin requires Vagrant 1.2+,
+**NOTE:** This plugin requires Vagrant 1.2+, ruby-dev build-essential libxml2-dev zlib1g-dev libcurl4-gnutls-dev
 
 ## Features
 


### PR DESCRIPTION
In addition to vagrant being installed, all of these other dependencies 
are required to be on the system in order for the installation of this 
plugin to be successful.

It's important for installers of this plugin to understand what needs to be installed on their system before attempting to install this plugin. Otherwise it will result in a lot of failed installations.

This PR would fix #571 