### PR TITLE
Use long-hand `Hash#slice` + `Hash#keys` instead of `Hash#except`

### DIFF
--- a/lib/vagrant-aws/action/connect_aws.rb
+++ b/lib/vagrant-aws/action/connect_aws.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
           @logger.info("Connecting to AWS...")
           env[:aws_compute] = Fog::Compute.new(fog_config)
-          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.except(:provider, :endpoint))
+          env[:aws_elb]     = Fog::AWS::ELB.new(fog_config.slice(fog_config.keys - [:provider, :endpoint]))
 
           @app.call(env)
         end


### PR DESCRIPTION
Since `Hash#except` is not in standard Ruby and Vagrant removed ~~`active_support`~~ `i18n` that provides the polyfill in Vagrant 2.2.7; even the polyfill was just `Hash#slice` minus the requested keys. Seemed simpler to inline than monkey-patch `Hash`...

Resolves mitchellh/vagrant-aws#566